### PR TITLE
added support for meshes with diffuse AND normal map

### DIFF
--- a/Obj2Gltf/Converter.cs
+++ b/Obj2Gltf/Converter.cs
@@ -296,6 +296,18 @@ namespace SilentWave.Obj2Gltf
                 };
             }
 
+
+            var hasNormalTexture = !string.IsNullOrEmpty(mat.NormalTextureFile);
+            if (hasNormalTexture)
+            {
+                var index = getOrAddTextureFunction(mat.NormalTextureFile);
+                gMat.normalTexture = new TextureReferenceInfo
+                {
+                    Index = index
+                };
+            }
+
+
             if (mat.Emissive != null && mat.Emissive.Color != null)
             {
                 gMat.EmissiveFactor = mat.Emissive.Color.ToArray();

--- a/Obj2Gltf/Gltf/Material.cs
+++ b/Obj2Gltf/Gltf/Material.cs
@@ -61,6 +61,12 @@ namespace SilentWave.Obj2Gltf.Gltf
         [JsonProperty("doubleSided")]
         public bool DoubleSided { get; set; }
 
+        /// <summary>
+        /// The normal texture.
+        /// </summary>
+        [JsonProperty("normalTexture")]
+        public TextureReferenceInfo normalTexture { get; set; }
+
         public override string ToString()
             => $"AM:{AlphaMode} DS:{(DoubleSided ? 1 : 0)} MRB:[{PbrMetallicRoughness.BaseColorFactor[0]}, {PbrMetallicRoughness.BaseColorFactor[1]}, {PbrMetallicRoughness.BaseColorFactor[2]}, {PbrMetallicRoughness.BaseColorFactor[3]}] E:[{EmissiveFactor[0]}, {EmissiveFactor[1]}, {EmissiveFactor[2]}] M:{PbrMetallicRoughness.MetallicFactor} R:{PbrMetallicRoughness.RoughnessFactor} T:{PbrMetallicRoughness.BaseColorTexture?.Index.ToString() ?? "<null>"} {Name}";
     }

--- a/Obj2Gltf/WaveFront/Material.cs
+++ b/Obj2Gltf/WaveFront/Material.cs
@@ -33,6 +33,10 @@ namespace SilentWave.Obj2Gltf.WaveFront
         /// </summary>
         public string AmbientTextureFile { get; set; }
         /// <summary>
+        /// norm: Normal texture file path
+        /// </summary>
+        public string NormalTextureFile { get; set; }
+        /// <summary>
         /// Ks: specular reflectivity of the current material
         /// </summary>
         public Reflectivity Specular { get; set; } = new Reflectivity(new FactorColor());

--- a/Obj2Gltf/WaveFront/MtlParser.cs
+++ b/Obj2Gltf/WaveFront/MtlParser.cs
@@ -19,6 +19,7 @@ namespace SilentWave.Obj2Gltf.WaveFront
         private const string NsPrefix = "Ns";
         private const string map_kaPrefix = "map_Ka";
         private const string map_KdPrefix = "map_Kd";
+        private const string normPrefix = "norm";
 
         private static Reflectivity GetReflectivity(string val)
         {
@@ -193,6 +194,14 @@ namespace SilentWave.Obj2Gltf.WaveFront
                         if (File.Exists(Path.Combine(searchPath, md)))
                         {
                             currentMaterial.DiffuseTextureFile = md;
+                        }
+                    }
+                    else if (line.StartsWith(normPrefix))
+                    {
+                        var mn = line.Substring(normPrefix.Length).Trim();
+                        if (File.Exists(Path.Combine(searchPath, mn)))
+                        {
+                            currentMaterial.NormalTextureFile = mn;
                         }
                     }
                 }

--- a/Obj2Tiles.Library/Materials/Material.cs
+++ b/Obj2Tiles.Library/Materials/Material.cs
@@ -8,6 +8,7 @@ public class Material : ICloneable
 {
     public readonly string Name;
     public string? Texture;
+    public string? NormalMap;
 
     /// <summary>
     /// Ka - Ambient
@@ -36,12 +37,13 @@ public class Material : ICloneable
 
     public readonly IlluminationModel? IlluminationModel;
 
-    public Material(string name, string? texture = null, RGB? ambientColor = null, RGB? diffuseColor = null,
+    public Material(string name, string? texture = null, string? normalMap = null, RGB? ambientColor = null, RGB? diffuseColor = null,
         RGB? specularColor = null, double? specularExponent = null, double? dissolve = null,
         IlluminationModel? illuminationModel = null)
     {
         Name = name;
         Texture = texture;
+        NormalMap = normalMap;
         AmbientColor = ambientColor;
         DiffuseColor = diffuseColor;
         SpecularColor = specularColor;
@@ -57,6 +59,7 @@ public class Material : ICloneable
         var deps = new List<string>();
 
         string texture = null;
+        string normalMap = null;
         var name = string.Empty;
         RGB? ambientColor = null, diffuseColor = null, specularColor = null;
         double? specularExponent = null, dissolve = null;
@@ -73,7 +76,7 @@ public class Material : ICloneable
                 case "newmtl":
 
                     if (name.Length > 0)
-                        materials.Add(new Material(name, texture, ambientColor, diffuseColor, specularColor,
+                        materials.Add(new Material(name, texture, normalMap, ambientColor, diffuseColor, specularColor,
                             specularExponent, dissolve, illuminationModel));
 
                     name = parts[1];
@@ -86,6 +89,14 @@ public class Material : ICloneable
                     
                     deps.Add(texture);
                     
+                    break;
+                case "norm":
+                    normalMap = Path.IsPathRooted(parts[1])
+                        ? parts[1]
+                        : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(path)!, parts[1]));
+
+                    deps.Add(normalMap);
+
                     break;
                 case "Ka":
                     ambientColor = new RGB(
@@ -123,7 +134,7 @@ public class Material : ICloneable
             }
         }
 
-        materials.Add(new Material(name, texture, ambientColor, diffuseColor, specularColor, specularExponent, dissolve,
+        materials.Add(new Material(name, texture, normalMap, ambientColor, diffuseColor, specularColor, specularExponent, dissolve,
             illuminationModel));
 
         dependencies = deps.ToArray();
@@ -142,6 +153,11 @@ public class Material : ICloneable
         {
             builder.Append("map_Kd ");
             builder.AppendLine(Texture.Replace('\\', '/'));
+        }
+        if (NormalMap != null)
+        {
+            builder.Append("norm ");
+            builder.AppendLine(NormalMap.Replace('\\', '/'));
         }
 
         if (AmbientColor != null)
@@ -188,6 +204,7 @@ public class Material : ICloneable
         return new Material(
             Name,
             Texture,
+            NormalMap,
             AmbientColor,
             DiffuseColor,
             SpecularColor,

--- a/Obj2Tiles.Library/Materials/Material.cs
+++ b/Obj2Tiles.Library/Materials/Material.cs
@@ -69,8 +69,9 @@ public class Material : ICloneable
         {
             if (line.StartsWith("#") || string.IsNullOrWhiteSpace(line))
                 continue;
-
-            var parts = line.Split(' ');
+            
+            var lineTrimmed = line.Trim();
+            var parts = lineTrimmed.Split(' ');
             switch (parts[0])
             {
                 case "newmtl":

--- a/Obj2Tiles/Utils.cs
+++ b/Obj2Tiles/Utils.cs
@@ -35,73 +35,73 @@ public static class Utils
 
         var dependencies = new List<string>();
 
-
+        
         foreach (var line in mtlFile)
         {
-            if (line.StartsWith("map_Kd"))
+            if (line.Trim().StartsWith("map_Kd"))
             {
                 dependencies.Add(line[7..].Trim());
 
                 continue;
             }
 
-            if (line.StartsWith("map_Ka"))
+            if (line.Trim().StartsWith("map_Ka"))
             {
                 dependencies.Add(line[7..].Trim());
 
                 continue;
             }
 
-            if (line.StartsWith("norm"))
+            if (line.Trim().StartsWith("norm"))
             {
                 dependencies.Add(line[5..].Trim());
 
                 continue;
             }
 
-            if (line.StartsWith("map_Ks"))
+            if (line.Trim().StartsWith("map_Ks"))
             {
                 dependencies.Add(line[7..].Trim());
 
                 continue;
             }
 
-            if (line.StartsWith("map_Bump"))
+            if (line.Trim().StartsWith("map_Bump"))
             {
                 dependencies.Add(line[8..].Trim());
 
                 continue;
             }
 
-            if (line.StartsWith("map_d"))
+            if (line.Trim().StartsWith("map_d"))
             {
                 dependencies.Add(line[6..].Trim());
 
                 continue;
             }
 
-            if (line.StartsWith("map_Ns"))
+            if (line.Trim().StartsWith("map_Ns"))
             {
                 dependencies.Add(line[7..].Trim());
 
                 continue;
             }
 
-            if (line.StartsWith("bump"))
+            if (line.Trim().StartsWith("bump"))
             {
                 dependencies.Add(line[5..].Trim());
 
                 continue;
             }
 
-            if (line.StartsWith("disp"))
+            if (line.Trim().StartsWith("disp"))
             {
                 dependencies.Add(line[5..].Trim());
 
                 continue;
             }
 
-            if (line.StartsWith("decal"))
+            if (line.Trim().StartsWith("decal"))
             {
                 dependencies.Add(line[6..].Trim());
 

--- a/Obj2Tiles/Utils.cs
+++ b/Obj2Tiles/Utils.cs
@@ -52,6 +52,13 @@ public static class Utils
                 continue;
             }
 
+            if (line.StartsWith("norm"))
+            {
+                dependencies.Add(line[5..].Trim());
+
+                continue;
+            }
+
             if (line.StartsWith("map_Ks"))
             {
                 dependencies.Add(line[7..].Trim());


### PR DESCRIPTION
Hey there. 

Following the issue #47, I modified obj2tiles in order tu support normal maps.

If you add the norm attribute in the .mtl file, the output 3DTiles will contain the normal map in its material.
Example:
````
newmtl default
Kd 0.5000000000 0.5000000000 0.5000000000
Ks 1.0000000000 1.0000000000 1.0000000000
Tr 0.0000000000
d 1.0000000000
Tf 1.0000000000 1.0000000000 1.0000000000
Pr 0.0000000000
Pm 0.0000000000
Pc 0.0000000000
Pcr 0.0000000000
Ni 1.5199999809
Ke 0.0000000000 0.0000000000 0.0000000000
illum 2
map_Kd textures\trap.png
norm textures\Box002NormalsMap.tga.png
````

- For some reason though, the normal map is showing only when there is also a diffuse map. I can't figure out why, as the normal map texture is indeed present in the 3D Tile. It might not even be related to  Obj2Tile, but if you have an idea...
- The normal texture and diffuse have the be the same size for obj2tiles to function correctly.


Thank you for reading me, I'd like to know what do you expect for this PR to be mergeable.



