### PR TITLE
Changes to support coordinate system that use units other than meters.

### DIFF
--- a/Obj2Tiles.Test/StagesTests.cs
+++ b/Obj2Tiles.Test/StagesTests.cs
@@ -47,7 +47,7 @@ public class StagesTests
                 Name = Path.GetFileNameWithoutExtension(file)
             }).ToDictionary(item => item.Name, item => item.Bounds);
     
-        StagesFacade.Tile("TestData/Tile1", testPath, 1, new[] { boundsMapper });
+        StagesFacade.Tile("TestData/Tile1", testPath, 1, 100, new[] { boundsMapper });
         
     }
 

--- a/Obj2Tiles/Options.cs
+++ b/Obj2Tiles/Options.cs
@@ -34,6 +34,12 @@ public sealed class Options
     
     [Option("alt", Required = false, HelpText = "Altitude of the mesh (meters)", Default = 0)]
     public double Altitude { get; set; }
+
+    [Option("scale", Required = false, HelpText = "Scale for data if using units other than meters ( 1200.0/3937.0 for survey ft)", Default = 1.0)]
+    public double Scale { get; set; }
+
+    [Option('e',"error", Required = false, HelpText = "Base error for root node", Default = 100.0)]
+    public double BaseError { get; set; }
     
     [Option("use-system-temp", Required = false, HelpText = "Uses the system temp folder", Default = false)]
     public bool UseSystemTempFolder { get; set; }

--- a/Obj2Tiles/Program.cs
+++ b/Obj2Tiles/Program.cs
@@ -82,15 +82,20 @@ namespace Obj2Tiles
                     return;
 
                 var gpsCoords = opts.Latitude != null && opts.Longitude != null
-                    ? new GpsCoords(opts.Latitude.Value, opts.Longitude.Value, opts.Altitude)
+                    ? new GpsCoords(opts.Latitude.Value, opts.Longitude.Value, opts.Altitude, opts.Scale)
                     : null;
 
                 Console.WriteLine();
                 Console.WriteLine($" => Tiling stage {(gpsCoords != null ? $"with GPS coords {gpsCoords}" : "")}");
 
+                var baseError = opts.BaseError;
+
+                Console.WriteLine();
+                Console.WriteLine($" => Tiling stage with baseError {baseError}");
+
                 sw.Restart();
 
-                StagesFacade.Tile(destFolderSplit, opts.Output, opts.LODs, boundsMapper, gpsCoords);
+                StagesFacade.Tile(destFolderSplit, opts.Output, opts.LODs, opts.BaseError, boundsMapper, gpsCoords);
 
                 Console.WriteLine(" ?> Tiling stage done in {0}", sw.Elapsed);
             }

--- a/Obj2Tiles/Stages/Model/GpsCoords.cs
+++ b/Obj2Tiles/Stages/Model/GpsCoords.cs
@@ -5,12 +5,14 @@ public class GpsCoords
     public double Latitude { get; set; }
     public double Longitude { get; set; }
     public double Altitude { get; set; }
+    public double Scale { get; set; }
 
-    public GpsCoords(double latitude, double longitude, double altitude)
+    public GpsCoords(double latitude, double longitude, double altitude, double scale)
     {
         Latitude = latitude;
         Longitude = longitude;
         Altitude = altitude;
+        Scale = scale;
     }
 
     public GpsCoords()
@@ -18,19 +20,21 @@ public class GpsCoords
         Latitude = 0;
         Longitude = 0;
         Altitude = 0;
+        Scale = 1;
     }
 
     public double[] ToEcefTransform()
     {
+        var s = Scale;
         var lat = Latitude * Math.PI / 180;
         var lon = Longitude * Math.PI / 180;
         var alt = Altitude;
 
-        const double a = 6378137;
-        const double b = 6356752.3142;
-        const double f = (a - b) / a;
+        var a = 6378137.0/s;
+        var b = 6356752.3142/s;
+        var f = (a - b) / a;
 
-        const double eSq = 2 * f - f * f;
+        var eSq = 2 * f - f * f;
 
         var sinLat = Math.Sin(lat);
         var cosLat = Math.Cos(lat);
@@ -63,9 +67,17 @@ public class GpsCoords
             0, 0, 0, 1
         };
 
+        var scale = new double[]
+        {
+            s, 0, 0, 0,
+            0, s, 0, 0,
+            0, 0, s, 0,
+            0, 0, 0, s
+        };
+
         var mult = MultiplyMatrix(res, rot);
 
-        return ConvertToColumnMajorOrder(mult);
+        return MultiplyMatrix(ConvertToColumnMajorOrder(mult), scale);
     }
 
     public static readonly double[] rot = {
@@ -112,6 +124,6 @@ public class GpsCoords
 
     public override string ToString()
     {
-        return $"{Latitude}, {Longitude}, {Altitude}";
+        return $"{Latitude}, {Longitude}, {Altitude}, {Scale}";
     }
 }

--- a/Obj2Tiles/Stages/Model/GpsCoords.cs
+++ b/Obj2Tiles/Stages/Model/GpsCoords.cs
@@ -72,7 +72,7 @@ public class GpsCoords
             s, 0, 0, 0,
             0, s, 0, 0,
             0, 0, s, 0,
-            0, 0, 0, s
+            0, 0, 0, 1
         };
 
         var mult = MultiplyMatrix(res, rot);

--- a/Obj2Tiles/Stages/TilingStage.cs
+++ b/Obj2Tiles/Stages/TilingStage.cs
@@ -11,7 +11,7 @@ namespace Obj2Tiles.Stages;
 
 public static partial class StagesFacade
 {
-    public static void Tile(string sourcePath, string destPath, int lods, Dictionary<string, Box3>[] boundsMapper,
+    public static void Tile(string sourcePath, string destPath, int lods, double baseError, Dictionary<string, Box3>[] boundsMapper,
         GpsCoords? coords = null)
     {
 
@@ -29,7 +29,7 @@ public static partial class StagesFacade
        
         // Don't ask me why 100, I have no idea but it works
         // https://github.com/CesiumGS/3d-tiles/issues/162
-        const int baseError = 100;
+        //const int baseError = 100;
 
         // Generate tileset.json
         var tileset = new Tileset

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ You can download precompiled binaries for Windows, Linux and macOS from https://
   --lat                  Latitude of the mesh
   --lon                  Longitude of the mesh
   --alt                  (Default: 0) Altitude of the mesh (meters)
+  -e, --error            (Default: 100), baseError value for root node
+  --scale                (Default: 1), scale for data if using units other than meters ( 1200.0/3937.0 for survey ft)  
   
   --use-system-temp      (Default: false) Uses the system temp folder
   --keep-intermediate    (Default: false) Keeps the intermediate files (do not cleanup)


### PR DESCRIPTION
Added a scale factor that can be used for proper tiles scaling if coordinate system uses units other than meters (i.e. survey feet or feet that are common in US). Code assumes that x, y and altitude are in different units and need to be scaled. 

Also added base Geometric error as a parameter. I found that 100 worked well for meters, but I need something like 300-500 for datasets that uses feet.