### PR TITLE
Consider remapping uv range [0, 1] to image pixel range [0, w-1] (or [0, h-1]) in MeshT.BinPackTextures

### DIFF
--- a/Obj2Tiles.Library/Geometry/MeshT.cs
+++ b/Obj2Tiles.Library/Geometry/MeshT.cs
@@ -491,8 +491,8 @@ public class MeshT : IMesh
 
             Debug.WriteLine("Cluster boundary (percentage): " + clusterBoundary);
 
-            var clusterX = (int)Math.Floor(clusterBoundary.Left * textureWidth);
-            var clusterY = (int)Math.Floor(clusterBoundary.Top * textureHeight);
+            var clusterX = (int)Math.Floor(clusterBoundary.Left * (textureWidth - 1));
+            var clusterY = (int)Math.Floor(clusterBoundary.Top * (textureHeight - 1));
             var clusterWidth = (int)Math.Max(Math.Ceiling(clusterBoundary.Width * textureWidth), 1);
             var clusterHeight = (int)Math.Max(Math.Ceiling(clusterBoundary.Height * textureHeight), 1);
 


### PR DESCRIPTION
In case where I have u = 1.0 or v 1.0 of `vt {u} {v}` in my obj file, the following line in `Obj2Tiles.Library.Common.CopyImage` will throw index out of range exception.
```C#
targetRow[x + destX] = sourceRow[x + sourceX];
```
I traced back and found that when `clusterBoundary.Left` (u) is exactly 1.0, clusterX will be equal to `textureWidth` and cause this problem.

Maybe we should consider remapping uv range [0, 1] to image pixel range [0, w-1] (or [0, h-1])?
```C#
          var clusterX = (int)Math.Floor(clusterBoundary.Left * (textureWidth - 1));
          var clusterY = (int)Math.Floor(clusterBoundary.Top * (textureHeight - 1));
```
As for uv out of range [0, 1], it might not be necessary to handle repetition.