### PR TITLE
Fix copy file behavior: Using trimmed line to get file path in Utils.cs

### DIFF
--- a/Obj2Tiles/Utils.cs
+++ b/Obj2Tiles/Utils.cs
@@ -86,7 +86,7 @@ public static class Utils
 
             if (trimmedLine.StartsWith("map_Ns"))
             {
-                dependencies.Add(trimmedLine[7..]);
+                dependencies.Add(trimmedLine[7..].Trim());
 
                 continue;
             }

--- a/Obj2Tiles/Utils.cs
+++ b/Obj2Tiles/Utils.cs
@@ -18,10 +18,12 @@ public static class Utils
 
         foreach (var line in objFile)
         {
-            if (!line.StartsWith("mtllib")) continue;
+            var trimmedLine = line.Trim();
 
-            var mtlPath = Path.Combine(folderName, line[7..].Trim());
-            dependencies.Add(line[7..].Trim());
+            if (!trimmedLine.StartsWith("mtllib")) continue;
+
+            var mtlPath = Path.Combine(folderName, trimmedLine[7..].Trim());
+            dependencies.Add(trimmedLine[7..].Trim());
 
             dependencies.AddRange(GetMtlDependencies(mtlPath));
         }
@@ -42,70 +44,70 @@ public static class Utils
             
             if (trimmedLine.StartsWith("map_Kd"))
             {
-                dependencies.Add(line[7..].Trim());
+                dependencies.Add(trimmedLine[7..].Trim());
 
                 continue;
             }
 
             if (trimmedLine.StartsWith("map_Ka"))
             {
-                dependencies.Add(line[7..].Trim());
+                dependencies.Add(trimmedLine[7..].Trim());
 
                 continue;
             }
 
             if (trimmedLine.StartsWith("norm"))
             {
-                dependencies.Add(line[5..].Trim());
+                dependencies.Add(trimmedLine[5..].Trim());
 
                 continue;
             }
 
             if (trimmedLine.StartsWith("map_Ks"))
             {
-                dependencies.Add(line[7..].Trim());
+                dependencies.Add(trimmedLine[7..].Trim());
 
                 continue;
             }
 
             if (trimmedLine.StartsWith("map_Bump"))
             {
-                dependencies.Add(line[8..].Trim());
+                dependencies.Add(trimmedLine[8..].Trim());
 
                 continue;
             }
 
             if (trimmedLine.StartsWith("map_d"))
             {
-                dependencies.Add(line[6..].Trim());
+                dependencies.Add(trimmedLine[6..].Trim());
 
                 continue;
             }
 
             if (trimmedLine.StartsWith("map_Ns"))
             {
-                dependencies.Add(line[7..].Trim());
+                dependencies.Add(trimmedLine[7..]);
 
                 continue;
             }
 
             if (trimmedLine.StartsWith("bump"))
             {
-                dependencies.Add(line[5..].Trim());
+                dependencies.Add(trimmedLine[5..].Trim());
 
                 continue;
             }
 
             if (trimmedLine.StartsWith("disp"))
             {
-                dependencies.Add(line[5..].Trim());
+                dependencies.Add(trimmedLine[5..].Trim());
 
                 continue;
             }
 
             if (trimmedLine.StartsWith("decal"))
             {
-                dependencies.Add(line[6..].Trim());
+                dependencies.Add(trimmedLine[6..].Trim());
 
                 continue;
             }


### PR DESCRIPTION
when there is blank chars in front of line `mtllib`, `map_Kd`, etc, file copying will fail because `line[7..].Trim()` didn't take indentation into account.
maybe we should use `trimmedLine` instead.