### PR TITLE
fixed exception when loading obj with texture coordinates but no material assigned

### DIFF
--- a/Obj2Tiles.Library/Geometry/MeshUtils.cs
+++ b/Obj2Tiles.Library/Geometry/MeshUtils.cs
@@ -88,6 +88,12 @@ public class MeshUtils
                         var vt2 = int.Parse(second[1]);
                         var vt3 = int.Parse(third[1]);
 
+                        var materialIndex = 0;
+                        if (currentMaterial != string.Empty)
+                        {
+                            materialIndex = materialsDict[currentMaterial];
+                        }
+
                         var faceT = new FaceT(
                             v1 - 1,
                             v2 - 1,
@@ -95,7 +101,7 @@ public class MeshUtils
                             vt1 - 1,
                             vt2 - 1,
                             vt3 - 1,
-                            materialsDict[currentMaterial]);
+                            materialIndex);
 
                         facesT.Add(faceT);
                     }


### PR DESCRIPTION
don't assume there's a material assigned because there are texture coordinates. this fixes an exception like this one: https://github.com/OpenDroneMap/Obj2Tiles/issues/31