### PR TITLE
Ensure GLB data is padded to 8-byte alignment so that validation checks pass

### DIFF
--- a/Obj2Gltf/BufferState.cs
+++ b/Obj2Gltf/BufferState.cs
@@ -173,7 +173,7 @@ namespace SilentWave.Obj2Gltf
                     Name = "Normals",
                     Buffer = _model.AddBuffer(NormalsBuffer),
                     ByteStride = 12,
-                    //Target = BufferViewTarget.ARRAY_BUFFER
+                    Target = BufferViewTarget.ARRAY_BUFFER
                 };
                 NormalsBufferViewIndex = _model.AddBufferView(NormalsBufferView);
             }
@@ -203,7 +203,7 @@ namespace SilentWave.Obj2Gltf
                     Name = "Uvs",
                     Buffer = _model.AddBuffer(UvsBuffer),
                     ByteStride = 8,
-                    //Target = BufferViewTarget.ARRAY_BUFFER
+                    Target = BufferViewTarget.ARRAY_BUFFER
                 };
                 UvsBufferViewIndex = _model.AddBufferView(UvsBufferView);
             }

--- a/Obj2Tiles/Stages/TilingStage.cs
+++ b/Obj2Tiles/Stages/TilingStage.cs
@@ -16,7 +16,7 @@ public static partial class StagesFacade
     {
 
         Console.WriteLine(" ?> Working on objs conversion");
-        
+
         ConvertAllB3dm(sourcePath, destPath, lods);
 
         Console.WriteLine(" -> Generating tileset.json");
@@ -26,7 +26,7 @@ public static partial class StagesFacade
             Console.WriteLine(" ?> Using default coordinates");
             coords = DefaultGpsCoords;
         }
-       
+
         // Don't ask me why 100, I have no idea but it works
         // https://github.com/CesiumGS/3d-tiles/issues/162
         //const int baseError = 100;
@@ -40,9 +40,7 @@ public static partial class StagesFacade
             {
                 GeometricError = baseError,
                 Refine = "ADD",
-
                 Transform = coords.ToEcefTransform(),
-                Children = new List<TileElement>()
             }
         };
 
@@ -54,11 +52,11 @@ public static partial class StagesFacade
         var minZ = double.MaxValue;
 
         var masterDescriptors = boundsMapper[0].Keys;
-        
+
         foreach (var descriptor in masterDescriptors)
         {
             var currentTileElement = tileset.Root;
-            
+
             var refBox = boundsMapper[0][descriptor];
 
             for (var lod = lods - 1; lod >= 0; lod--)
@@ -87,7 +85,6 @@ public static partial class StagesFacade
                     {
                         GeometricError = lod == 0 ? 0 : CalculateGeometricError(refBox, box3, lod),
                         Refine = "REPLACE",
-                        Children = new List<TileElement>(),
                         Content = new Content
                         {
                             Uri = $"LOD-{lod}/{Path.GetFileNameWithoutExtension(descriptor)}.b3dm"
@@ -95,6 +92,8 @@ public static partial class StagesFacade
                         BoundingVolume = box3.ToBoundingVolume()
                     };
 
+                    if (currentTileElement.Children == null)
+                        currentTileElement.Children = new List<TileElement>();
                     currentTileElement.Children.Add(tile);
                     currentTileElement = tile;
                 }
@@ -116,7 +115,7 @@ public static partial class StagesFacade
         var dW = Math.Abs(refBox.Width - box.Width) / box.Width + 1;
         var dH = Math.Abs(refBox.Height - box.Height) / box.Height + 1;
         var dD = Math.Abs(refBox.Depth - box.Depth) / box.Depth + 1;
-       
+
         return Math.Pow(dW + dH + dD, lod);
 
     }

--- a/Obj2Tiles/Tiles/B3dm.cs
+++ b/Obj2Tiles/Tiles/B3dm.cs
@@ -30,10 +30,13 @@ namespace Obj2Tiles.Tiles
         {
             const int headerLength = 28;
 
-            var featureTableJson = BufferPadding.AddPadding(FeatureTableJson);
+            var featureTableJson = BufferPadding.AddPadding(FeatureTableJson, headerLength);
             var batchTableJson = BufferPadding.AddPadding(BatchTableJson);
             var featureTableBinary = BufferPadding.AddPadding(FeatureTableBinary);
             var batchTableBinary = BufferPadding.AddPadding(BatchTableBinary);
+
+            // Ensure GLB data is padded to 8-byte alignment
+            GlbData = BufferPadding.AddPadding(GlbData);
 
             B3dmHeader.ByteLength = GlbData.Length + headerLength + featureTableJson.Length + Encoding.UTF8.GetByteCount(batchTableJson) + batchTableBinary.Length + FeatureTableBinary.Length;
 


### PR DESCRIPTION
In order for data validation checks pass when using [3d-tiles-validator](https://github.com/CesiumGS/3d-tiles-validator), it is required that the tile bytelength is packed to 8-byte boundary.
In order to do this, we must pad the potentially unbounded gltf file so that the validation check pass.
In the latest [discussions ](https://github.com/CesiumGS/3d-tiles/pull/759) it is clarified that padding should be added to the end of the .b3dm tile instead od padding the binary gltf file.

What the spec requires (so the validator stops complaining):

- Tile byteLength: must be aligned to 8 bytes. 
- GLB inside b3dm: must start and end on an 8-byte boundary (relative to the start of the b3dm). This is in addition to glTF’s own 4-byte chunk rules. 
- JSON sections (Feature/Batch tables): the JSON must end on an 8-byte boundary and is padded with space bytes (0x20). 
- Binary sections (Feature/Batch tables): must start and end on an 8-byte boundary and are padded with 0x00. 

What is done:

- Because the b3dm header is 28 bytes (28 ≡ 4 mod 8), the usual trick is:
1. Feature Table JSON length ≡ 4 mod 8 (e.g., "{}" + 2 spaces → 4 bytes), so that 28 + FTJSON ends on an 8-byte boundary.
2. All following sections (FT binary, BT JSON, BT binary) end on 8-byte boundaries (pad with 0x00 for binaries, 0x20 for JSON).

 That guarantees the GLB starts on an 8-byte boundary.
Additionally ensure the GLB length is a multiple of 8, or pad with 0x20 after the .glb data

this should fix #77  and #46 
