### PR TITLE
Add Dockerfile & ghcr container build workflow

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,55 @@
+name: Image Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    tags: ["*"]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/obj2tiles
+
+      - name: Set up QEMU emulator for multi-arch images
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push container image
+        uses: docker/build-push-action@v7
+        with:
+            file: Dockerfile
+            context: .
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            platforms: linux/amd64,linux/arm64
+            cache-from: type=gha
+            cache-to: type=gha,mode=max

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -34,7 +34,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/obj2tiles
+          images: ${{ env.REGISTRY }}/opendronemap/obj2tiles
 
       - name: Set up QEMU emulator for multi-arch images
         uses: docker/setup-qemu-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,6 @@ RUN DOTNET_RID=$([ "$TARGETARCH" = "arm64" ] && echo "linux-arm64" || echo "linu
 # Minimal runtime
 FROM mcr.microsoft.com/dotnet/runtime-deps:10.0
 WORKDIR /data
-COPY --from=build /app/Obj2Tiles /usr/local/bin/obj2tiles
+COPY --from=build /app/ /app/
 
-ENTRYPOINT ["obj2tiles"]
+ENTRYPOINT ["/app/Obj2Tiles"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG TARGETARCH
+WORKDIR /source
+
+# Copy project files first so dependency restore is cached independently of source changes
+COPY Obj2Tiles.sln .
+COPY Obj2Tiles/Obj2Tiles.csproj Obj2Tiles/
+COPY Obj2Tiles.Library/Obj2Tiles.Library.csproj Obj2Tiles.Library/
+COPY MeshDecimatorCore/MeshDecimatorCore.csproj MeshDecimatorCore/
+COPY Obj2Gltf/Obj2Gltf.csproj Obj2Gltf/
+
+RUN DOTNET_RID=$([ "$TARGETARCH" = "arm64" ] && echo "linux-arm64" || echo "linux-x64") && \
+    dotnet restore Obj2Tiles/Obj2Tiles.csproj -r $DOTNET_RID
+
+# Copy source and publish as a self-contained single-file binary
+COPY Obj2Tiles/ Obj2Tiles/
+COPY Obj2Tiles.Library/ Obj2Tiles.Library/
+COPY MeshDecimatorCore/ MeshDecimatorCore/
+COPY Obj2Gltf/ Obj2Gltf/
+
+RUN DOTNET_RID=$([ "$TARGETARCH" = "arm64" ] && echo "linux-arm64" || echo "linux-x64") && \
+    dotnet publish Obj2Tiles/Obj2Tiles.csproj \
+    -c Release \
+    -r $DOTNET_RID \
+    --self-contained true \
+    -p:PublishSingleFile=true \
+    -p:PublishTrimmed=true \
+    -p:TrimMode=partial \
+    -p:TrimmerRemoveSymbols=true \
+    -p:DebuggerSupport=false \
+    --no-restore \
+    -o /app
+
+
+# Minimal runtime
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0
+WORKDIR /data
+COPY --from=build /app/Obj2Tiles /usr/local/bin/obj2tiles
+
+ENTRYPOINT ["obj2tiles"]


### PR DESCRIPTION
- I wanted to give Obj2Tiles a whirl to convert ODM .obj --> 3d tiles (to view in a browser).
- In order to do so, and without installing dotnet on my machine, I decided to create a Dockerfile and build a container image.
- I have tested the image locally and it works.
- Also added a ghcr publishing workflow that will build a `:master` tagged image on each push, in addition to tagged `:v1.4.0` tag when a new tag is pushed.