### PR TITLE
Add support for octree, texture downscaling and other improvements

### DIFF
--- a/Obj2Tiles.Library.Test/MtlParsingTests.cs
+++ b/Obj2Tiles.Library.Test/MtlParsingTests.cs
@@ -148,4 +148,58 @@ public class MtlParsingTests
             File.Delete(tempFile);
         }
     }
+
+    [Test]
+    public void ReadMtl_StripsLeadingOptions_FindsTexture()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "diffuse.png"), "x");
+            var mtl = Path.Combine(dir, "m.mtl");
+            File.WriteAllText(mtl, "newmtl X\nmap_Kd -bm 1.0 diffuse.png\n");
+            var materials = Material.ReadMtl(mtl, out var deps);
+            materials[0].Texture.ShouldNotBeNull();
+            materials[0].Texture!.EndsWith("diffuse.png").ShouldBeTrue();
+            deps.Length.ShouldBe(1);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Test]
+    public void ReadMtl_PathWithSpaces_ResolvesAfterNumericOptions()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "my tex.png"), "x");
+            var mtl = Path.Combine(dir, "m.mtl");
+            File.WriteAllText(mtl, "newmtl X\nmap_Kd -s 1 1 1 my tex.png\n");
+            var materials = Material.ReadMtl(mtl, out _);
+            materials[0].Texture.ShouldNotBeNull();
+            materials[0].Texture!.EndsWith("my tex.png").ShouldBeTrue();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Test]
+    public void ReadMtl_Newmtl_ResetsTexturePerMaterial()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "t.png"), "x");
+            var mtl = Path.Combine(dir, "m.mtl");
+            File.WriteAllText(mtl, "newmtl A\nmap_Kd t.png\nnewmtl B\nKd 0.5 0.5 0.5\n");
+            var materials = Material.ReadMtl(mtl, out _);
+            materials.Length.ShouldBe(2);
+            materials[0].Texture.ShouldNotBeNull();
+            materials[1].Texture.ShouldBeNull();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
 }

--- a/Obj2Tiles.Library.Test/Obj2Tiles.Library.Test.csproj
+++ b/Obj2Tiles.Library.Test/Obj2Tiles.Library.Test.csproj
@@ -136,6 +136,12 @@
       <None Update="TestData\multi-material.mtl">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="TestData\spaced-mtllib.obj">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="TestData\spaced name.mtl">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
       <None Update="TestData\cube-3d.obj">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>

--- a/Obj2Tiles.Library.Test/ObjParsingTests.cs
+++ b/Obj2Tiles.Library.Test/ObjParsingTests.cs
@@ -184,6 +184,19 @@ public class ObjParsingTests
     }
 
     [Test]
+    public void LoadMesh_MtlFileNameWithSpaces_LoadsMaterialsCorrectly()
+    {
+        // Fixed: mtllib line with spaces in the filename was truncated to the first
+        // word (segs.Length == 2 guard), so the MTL was never loaded and every
+        // subsequent usemtl threw "Material X not found".
+        var mesh = MeshUtils.LoadMesh(Path.Combine(TestDataPath, "spaced-mtllib.obj"), out var deps);
+
+        mesh.ShouldBeOfType<MeshT>();
+        mesh.FacesCount.ShouldBe(1);
+        deps.Length.ShouldBeGreaterThan(0);
+    }
+
+    [Test]
     public void LoadMesh_MissingMtlFile_ThrowsFileNotFound()
     {
         // mtllib points to a non-existent file → should throw (not "Access denied")

--- a/Obj2Tiles.Library.Test/TestData/spaced name.mtl
+++ b/Obj2Tiles.Library.Test/TestData/spaced name.mtl
@@ -1,0 +1,6 @@
+newmtl Baking.002
+Ka 0.0 0.0 0.0
+Kd 0.8 0.4 0.2
+Ks 0.0 0.0 0.0
+d 1.0
+illum 1

--- a/Obj2Tiles.Library.Test/TestData/spaced-mtllib.obj
+++ b/Obj2Tiles.Library.Test/TestData/spaced-mtllib.obj
@@ -1,0 +1,9 @@
+mtllib spaced name.mtl
+v 0 0 0
+v 1 0 0
+v 0.5 1 0
+vt 0 0
+vt 1 0
+vt 0.5 1
+usemtl Baking.002
+f 1/1 2/2 3/3

--- a/Obj2Tiles.Library/Algos/MaxRectanglesBinPack.cs
+++ b/Obj2Tiles.Library/Algos/MaxRectanglesBinPack.cs
@@ -478,40 +478,32 @@ namespace Obj2Tiles.Library.Algos
 
         private void PruneFreeList()
         {
-            var rectanglesToRemove = new SortedSet<int>();
+            var toRemove = new bool[freeRectangles.Count];
 
             for (var i = 0; i < freeRectangles.Count; i++)
             {
+                if (toRemove[i]) continue;
+
                 for (var j = i + 1; j < freeRectangles.Count; ++j)
                 {
-                    if (rectanglesToRemove.Contains(j) || rectanglesToRemove.Contains(i))
-                    {
-                        break;
-                    }
+                    if (toRemove[j])
+                        continue;
 
                     if (freeRectangles[j].Contains(freeRectangles[i]))
                     {
-                        lock (rectanglesToRemove)
-                        {
-                            rectanglesToRemove.Add(i);
-                        }
-
+                        toRemove[i] = true;
                         break;
                     }
 
                     if (freeRectangles[i].Contains(freeRectangles[j]))
-                    {
-                        lock (rectanglesToRemove)
-                        {
-                            rectanglesToRemove.Add(j);
-                        }
-                    }
+                        toRemove[j] = true;
                 }
             }
 
-            foreach (var rectangleToRemove in rectanglesToRemove.Reverse())
+            for (var i = toRemove.Length - 1; i >= 0; i--)
             {
-                freeRectangles.RemoveAt(rectangleToRemove);
+                if (toRemove[i])
+                    freeRectangles.RemoveAt(i);
             }
         }
     }

--- a/Obj2Tiles.Library/Geometry/IMesh.cs
+++ b/Obj2Tiles.Library/Geometry/IMesh.cs
@@ -3,6 +3,7 @@
 public interface IMesh
 {
     string Name { get; set; }
+    string DebugName { get; set; }
     Box3 Bounds { get; }
     IReadOnlyList<Vertex3> Vertices { get; }
 

--- a/Obj2Tiles.Library/Geometry/Mesh.cs
+++ b/Obj2Tiles.Library/Geometry/Mesh.cs
@@ -19,6 +19,7 @@ public class Mesh : IMesh
     public const string DefaultName = "Mesh";
 
     public string Name { get; set; } = DefaultName;
+    public string DebugName { get; set; } = string.Empty;
 
     public Mesh(IEnumerable<Vertex3> vertices, IEnumerable<Face> faces, IEnumerable<RGB>? vertexColors = null)
     {

--- a/Obj2Tiles.Library/Geometry/MeshT.cs
+++ b/Obj2Tiles.Library/Geometry/MeshT.cs
@@ -31,6 +31,13 @@ public class MeshT : IMesh
 
     public TexturesStrategy TexturesStrategy { get; set; }
 
+    /// <summary>
+    /// Multiplier applied to the atlas edge length during texture repacking.
+    /// 1.0 = full resolution, 0.5 = half, 0.25 = quarter, etc.
+    /// Values are clamped to (0, 1]. Only has effect with Repack or RepackCompressed.
+    /// </summary>
+    public float TextureDownscale { get; set; } = 1.0f;
+
     public MeshT(IEnumerable<Vertex3> vertices, IEnumerable<Vertex2> textureVertices,
         IEnumerable<FaceT> faces, IEnumerable<Material> materials, IEnumerable<RGB>? vertexColors = null)
     {
@@ -547,9 +554,13 @@ public class MeshT : IMesh
         int textureWidth = material.Texture != null ? texture!.Width : normalMap!.Width;
         int textureHeight = material.Texture != null ? texture!.Height : normalMap!.Height;
 
+        float scale = Math.Clamp(TextureDownscale, float.Epsilon, 1.0f);
+        int effWidth  = Math.Max(1, (int)(textureWidth  * scale));
+        int effHeight = Math.Max(1, (int)(textureHeight * scale));
+
         var clustersRects = clusters.Select(GetClusterRect).ToArray();
 
-        CalculateMaxMinAreaRect(clustersRects, textureWidth, textureHeight, PADDING, out var maxWidth, out var maxHeight,
+        CalculateMaxMinAreaRect(clustersRects, effWidth, effHeight, PADDING, out var maxWidth, out var maxHeight,
             out var textureArea);
 
         Debug.WriteLine("Texture area: " + textureArea);
@@ -615,8 +626,12 @@ public class MeshT : IMesh
             int syTL = Math.Clamp(textureHeight - eb, 0, textureHeight - sh);
             var srcRect = new Rectangle(sx, syTL, sw, sh);
 
+            // Atlas-space dimensions (may be smaller than source when TextureDownscale < 1)
+            int scaledSw = Math.Max(1, (int)Math.Round(sw * scale));
+            int scaledSh = Math.Max(1, (int)Math.Round(sh * scale));
+
             // ---------- reserve atlas space WITH padding ----------
-            var packRect = binPack.Insert(sw + 2 * PADDING, sh + 2 * PADDING,
+            var packRect = binPack.Insert(scaledSw + 2 * PADDING, scaledSh + 2 * PADDING,
                                           FreeRectangleChoiceHeuristic.RectangleBestAreaFit);
 
             // If we ran out of room: save current atlas, start a new one (keeps your behavior)
@@ -654,10 +669,10 @@ public class MeshT : IMesh
                 materialIndex = _materials.Count - 1;
 
                 // try again
-                packRect = binPack.Insert(sw + 2 * PADDING, sh + 2 * PADDING,
+                packRect = binPack.Insert(scaledSw + 2 * PADDING, scaledSh + 2 * PADDING,
                                           FreeRectangleChoiceHeuristic.RectangleBestAreaFit);
                 if (packRect.Width == 0)
-                    throw new Exception($"Packing failed for {sw}x{sh} into {edgeLength}x{edgeLength} (occ {binPack.Occupancy()})");
+                    throw new Exception($"Packing failed for {scaledSw}x{scaledSh} into {edgeLength}x{edgeLength} (occ {binPack.Occupancy()})");
             }
 
             int destInnerX = packRect.X + PADDING;
@@ -669,22 +684,22 @@ public class MeshT : IMesh
             if (material.Texture != null)
             {
                 using var block = BuildPaddedBlock(texture!, srcRect, PADDING);
+                if (scale < 1.0f)
+                    block.Mutate(ctx => ctx.Resize(scaledSw + 2 * PADDING, scaledSh + 2 * PADDING));
                 newTexture!.Mutate(c => c.DrawImage(block, new Point(destOuterX, destOuterY), 1f));
             }
             if (material.NormalMap != null)
             {
                 using var blockN = BuildPaddedBlock(normalMap!, srcRect, PADDING);
+                if (scale < 1.0f)
+                    blockN.Mutate(ctx => ctx.Resize(scaledSw + 2 * PADDING, scaledSh + 2 * PADDING));
                 newNormalMap!.Mutate(c => c.DrawImage(blockN, new Point(destOuterX, destOuterY), 1f));
             }
 
-            // Inner rect size in pixels
-            double innerWpx = sw;                 // crop width
-            double innerHpx = sh;                 // crop height
-
             double atlasU0 = destInnerX / (double)edgeLength;
-            double atlasV0 = (edgeLength - (destInnerY + sh)) / (double)edgeLength;
-            double innerUw = sw / (double)edgeLength;
-            double innerVh = sh / (double)edgeLength;
+            double atlasV0 = (edgeLength - (destInnerY + scaledSh)) / (double)edgeLength;
+            double innerUw = scaledSw / (double)edgeLength;
+            double innerVh = scaledSh / (double)edgeLength;
 
             Vertex2 MapUV(double rx, double ry) =>
                 new((float)Math.Clamp(atlasU0 + rx * innerUw, 0, 1),

--- a/Obj2Tiles.Library/Geometry/MeshT.cs
+++ b/Obj2Tiles.Library/Geometry/MeshT.cs
@@ -867,11 +867,12 @@ public class MeshT : IMesh
     {
 
         var clusters = new List<List<int>>();
-        var remainingFacesIndexes = new List<int>(facesIndexes);
+        var remainingFacesIndexes = new HashSet<int>(facesIndexes);
 
-        var currentCluster = new List<int> { remainingFacesIndexes[0] };
-        var currentClusterCache = new HashSet<int> { remainingFacesIndexes[0] };
-        remainingFacesIndexes.RemoveAt(0);
+        var first = remainingFacesIndexes.First();
+        var currentCluster = new List<int> { first };
+        var currentClusterCache = new HashSet<int> { first };
+        remainingFacesIndexes.Remove(first);
 
         var lastRemainingFacesCount = remainingFacesIndexes.Count;
 
@@ -907,9 +908,10 @@ public class MeshT : IMesh
                 if (remainingFacesIndexes.Count == 0) break;
 
                 // Let's continue with the next cluster
-                currentCluster = [remainingFacesIndexes[0]];
-                currentClusterCache = [remainingFacesIndexes[0]];
-                remainingFacesIndexes.RemoveAt(0);
+                var next = remainingFacesIndexes.First();
+                currentCluster = [next];
+                currentClusterCache = [next];
+                remainingFacesIndexes.Remove(next);
             }
 
             if (lastRemainingFacesCount == remainingFacesIndexes.Count)

--- a/Obj2Tiles.Library/Geometry/MeshT.cs
+++ b/Obj2Tiles.Library/Geometry/MeshT.cs
@@ -658,16 +658,12 @@ public class MeshT : IMesh
 
             if (material.Texture != null)
             {
-                using var block = BuildPaddedBlock(texture!, srcRect, PADDING);
-                if (scale < 1.0f)
-                    block.Mutate(ctx => ctx.Resize(scaledSw + 2 * PADDING, scaledSh + 2 * PADDING));
+                using var block = BuildPaddedBlock(texture!, srcRect, PADDING, scaledSw, scaledSh);
                 newTexture!.Mutate(c => c.DrawImage(block, new Point(destOuterX, destOuterY), 1f));
             }
             if (material.NormalMap != null)
             {
-                using var blockN = BuildPaddedBlock(normalMap!, srcRect, PADDING);
-                if (scale < 1.0f)
-                    blockN.Mutate(ctx => ctx.Resize(scaledSw + 2 * PADDING, scaledSh + 2 * PADDING));
+                using var blockN = BuildPaddedBlock(normalMap!, srcRect, PADDING, scaledSw, scaledSh);
                 newNormalMap!.Mutate(c => c.DrawImage(blockN, new Point(destOuterX, destOuterY), 1f));
             }
 
@@ -1235,33 +1231,49 @@ public class MeshT : IMesh
         _vertexColors = newColors;
     }
 
-    // Build a padded chart block by duplicating edge texels via direct pixel access.
-    // Each output pixel maps to a clamped source coordinate, handling interior, strips and corners uniformly.
-    private static Image<Rgba32> BuildPaddedBlock(Image<Rgba32> src, Rectangle srcRect, int padding)
+    // Crop the source rect, resize to (scaledW x scaledH), then add a padding-wide bleed ring by
+    // edge-pixel repetition. Resizing before padding ensures the interior occupies exactly
+    // [padding, padding+scaledW) in the returned block regardless of the scale factor.
+    private static Image<Rgba32> BuildPaddedBlock(Image<Rgba32> src, Rectangle srcRect, int padding, int scaledW, int scaledH)
     {
         int sx = Math.Clamp(srcRect.X, 0, Math.Max(0, src.Width - 1));
         int sy = Math.Clamp(srcRect.Y, 0, Math.Max(0, src.Height - 1));
         int sw = Math.Clamp(srcRect.Width, 1, src.Width - sx);
         int sh = Math.Clamp(srcRect.Height, 1, src.Height - sy);
 
-        var block = new Image<Rgba32>(sw + 2 * padding, sh + 2 * padding);
-
-        src.ProcessPixelRows(block, (srcAcc, blockAcc) =>
+        // Step 1: crop the interior at full source resolution.
+        using var interior = new Image<Rgba32>(sw, sh);
+        src.ProcessPixelRows(interior, (srcAcc, intAcc) =>
         {
-            for (int destY = 0; destY < blockAcc.Height; destY++)
+            for (int y = 0; y < sh; y++)
             {
-                int srcY = Math.Clamp(destY - padding, 0, sh - 1) + sy;
-                var srcRow = srcAcc.GetRowSpan(srcY);
-                var destRow = blockAcc.GetRowSpan(destY);
-
-                for (int destX = 0; destX < blockAcc.Width; destX++)
-                {
-                    int srcX = Math.Clamp(destX - padding, 0, sw - 1) + sx;
-                    destRow[destX] = srcRow[srcX];
-                }
+                var srcRow = srcAcc.GetRowSpan(sy + y);
+                var intRow = intAcc.GetRowSpan(y);
+                for (int x = 0; x < sw; x++)
+                    intRow[x] = srcRow[sx + x];
             }
         });
 
+        // Step 2: resize the interior to the target atlas dimensions (skipped when 1:1).
+        if (scaledW != sw || scaledH != sh)
+            interior.Mutate(ctx => ctx.Resize(scaledW, scaledH));
+
+        // Step 3: add the bleed ring from the (now resized) interior edge pixels.
+        var block = new Image<Rgba32>(scaledW + 2 * padding, scaledH + 2 * padding);
+        interior.ProcessPixelRows(block, (intAcc, blockAcc) =>
+        {
+            for (int destY = 0; destY < blockAcc.Height; destY++)
+            {
+                int intY = Math.Clamp(destY - padding, 0, scaledH - 1);
+                var intRow = intAcc.GetRowSpan(intY);
+                var destRow = blockAcc.GetRowSpan(destY);
+                for (int destX = 0; destX < blockAcc.Width; destX++)
+                {
+                    int intX = Math.Clamp(destX - padding, 0, scaledW - 1);
+                    destRow[destX] = intRow[intX];
+                }
+            }
+        });
         return block;
     }
 

--- a/Obj2Tiles.Library/Geometry/MeshT.cs
+++ b/Obj2Tiles.Library/Geometry/MeshT.cs
@@ -28,6 +28,7 @@ public class MeshT : IMesh
     public const string DefaultName = "Mesh";
 
     public string Name { get; set; } = DefaultName;
+    public string DebugName { get; set; } = string.Empty;
 
     public TexturesStrategy TexturesStrategy { get; set; }
 
@@ -460,8 +461,6 @@ public class MeshT : IMesh
 
     private void TrimTextures(string targetFolder)
     {
-        Debug.WriteLine("Trimming textures of " + Name);
-
         var tasks = new List<Task>();
 
         LoadTexturesCache();
@@ -470,60 +469,37 @@ public class MeshT : IMesh
 
         var newTextureVertices = new Dictionary<Vertex2, int>(_textureVertices.Count);
 
-        var sw = new Stopwatch();
-
         for (var m = 0; m < facesByMaterial.Count; m++)
         {
             var material = _materials[m];
             var facesIndexes = facesByMaterial[m];
-            Debug.WriteLine($"Working on material {m} -> {material.Name}");
 
             if (facesIndexes.Count == 0)
-            {
-                Debug.WriteLine("No faces with this material");
                 continue;
-            }
 
-            sw.Restart();
-
-            Debug.WriteLine("Creating edges mapper");
             var edgesMapper = GetEdgesMapper(facesIndexes);
-            Debug.WriteLine("Done in " + sw.ElapsedMilliseconds + "ms");
-            sw.Restart();
-
-            Debug.WriteLine("Creating faces mapper");
             var facesMapper = GetFacesMapper(edgesMapper);
-            Debug.WriteLine("Done in " + sw.ElapsedMilliseconds + "ms");
-            sw.Restart();
-
-            Debug.WriteLine("Assembling faces clusters");
             var clusters = GetFacesClusters(facesIndexes, facesMapper);
-            Debug.WriteLine("Done in " + sw.ElapsedMilliseconds + "ms");
-            sw.Restart();
-
-            Debug.WriteLine("Sorting clusters");
 
             // Sort clusters by count (improves packing density, could be removed if we notice a bottleneck)
             clusters.Sort((a, b) => b.Count.CompareTo(a.Count));
-            Debug.WriteLine("Done in " + sw.ElapsedMilliseconds + "ms");
-            sw.Restart();
 
-            Debug.WriteLine($"Material {material.Name} has {clusters.Count} clusters");
-
-            Debug.WriteLine("Bin packing clusters");
             BinPackTextures(targetFolder, m, clusters, newTextureVertices, tasks);
-            Debug.WriteLine("Done in " + sw.ElapsedMilliseconds + "ms");
         }
 
-        Debug.WriteLine("Sorting new texture vertices");
-        sw.Restart();
         _textureVertices = newTextureVertices.OrderBy(item => item.Value).Select(item => item.Key).ToList();
-        Debug.WriteLine("Done in " + sw.ElapsedMilliseconds + "ms");
 
-        Debug.WriteLine("Waiting for save tasks to finish");
-        sw.Restart();
-        Task.WaitAll(tasks.ToArray());
-        Debug.WriteLine("Done in " + sw.ElapsedMilliseconds + "ms");
+        var allSaves = Task.WhenAll(tasks);
+        var saveSw = Stopwatch.StartNew();
+        long nextSaveProgressMs = 5000;
+        while (!allSaves.Wait(100))
+        {
+            if (saveSw.ElapsedMilliseconds >= nextSaveProgressMs)
+            {
+                Console.WriteLine($" -> [{DebugName}] Saving texture atlases... ({saveSw.Elapsed.TotalSeconds:F0}s)");
+                nextSaveProgressMs += 5000;
+            }
+        }
     }
 
     private void LoadTexturesCache()
@@ -544,6 +520,9 @@ public class MeshT : IMesh
     {
         const int PADDING = 2; // <-- bleed ring
 
+        var packSw = Stopwatch.StartNew();
+        long nextProgressMs = 5000;
+
         var material = _materials[materialIndex];
 
         if (material.Texture == null && material.NormalMap == null) return;
@@ -563,8 +542,6 @@ public class MeshT : IMesh
         CalculateMaxMinAreaRect(clustersRects, effWidth, effHeight, PADDING, out var maxWidth, out var maxHeight,
             out var textureArea);
 
-        Debug.WriteLine("Texture area: " + textureArea);
-
         var edgeLength = Math.Max(Common.NextPowerOfTwo((int)Math.Sqrt(textureArea)), 32);
 
         if (edgeLength < maxWidth)
@@ -572,8 +549,6 @@ public class MeshT : IMesh
 
         if (edgeLength < maxHeight)
             edgeLength = Common.NextPowerOfTwo((int)maxHeight);
-
-        Debug.WriteLine("Edge length: " + edgeLength);
 
         // NOTE: We could enable rotations but it would be a bit more complex
         var binPack = new MaxRectanglesBinPack(edgeLength, edgeLength, false);
@@ -735,6 +710,12 @@ public class MeshT : IMesh
                 face.TextureIndexC = newIndexVtC;
                 face.MaterialIndex = materialIndex;
             }
+
+            if (packSw.ElapsedMilliseconds >= nextProgressMs)
+            {
+                Console.WriteLine($" -> [{DebugName}] Repacking texture '{_materials[materialIndex].Name}': {i + 1}/{clusters.Count} ({(i + 1) * 100 / clusters.Count}%) clusters ({packSw.Elapsed.TotalSeconds:F0}s)...");
+                nextProgressMs += 5000;
+            }
         }
 
         // ---------- saving (unchanged) ----------
@@ -763,7 +744,6 @@ public class MeshT : IMesh
                 case TexturesStrategy.Repack: tx.Save(newPathTexture!); break;
                 default: throw new InvalidOperationException("KeepOriginal/Compress are meaningless here");
             }
-            Debug.WriteLine("Saved texture to " + newPathTexture);
             tx.Dispose();
         }, newTexture, TaskCreationOptions.LongRunning);
 
@@ -776,7 +756,6 @@ public class MeshT : IMesh
                 case TexturesStrategy.Repack: tx.Save(newPathNormalMap!); break;
                 default: throw new InvalidOperationException("KeepOriginal/Compress are meaningless here");
             }
-            Debug.WriteLine("Saved texture to " + newPathNormalMap);
             tx.Dispose();
         }, newNormalMap, TaskCreationOptions.LongRunning);
 
@@ -1122,7 +1101,9 @@ public class MeshT : IMesh
 
     public void WriteObj(string path, bool removeUnused = true)
     {
-        if (_materials.Count == 0 || _textureVertices.Count == 0)
+        var hasTextures = _materials.Count > 0 && _textureVertices.Count > 0;
+        //Console.WriteLine($" -> '{Name}': {(hasTextures ? $"{_materials.Count} mat(s), {_textureVertices.Count} UVs [{TexturesStrategy}]" : "no textures")}");
+        if (!hasTextures)
             _WriteObjWithoutTexture(path, removeUnused);
         else
             _WriteObjWithTexture(path, removeUnused);
@@ -1310,7 +1291,6 @@ public class MeshT : IMesh
 
         if (TexturesStrategy == TexturesStrategy.Repack || TexturesStrategy == TexturesStrategy.RepackCompressed)
             TrimTextures(folderPath);
-
         using (var writer = new FormattingStreamWriter(path, CultureInfo.InvariantCulture))
         {
             writer.Write("o ");

--- a/Obj2Tiles.Library/Geometry/MeshT.cs
+++ b/Obj2Tiles.Library/Geometry/MeshT.cs
@@ -1235,46 +1235,32 @@ public class MeshT : IMesh
         _vertexColors = newColors;
     }
 
-    // Build a padded chart block by duplicating edge texels (ImageSharp-safe)
+    // Build a padded chart block by duplicating edge texels via direct pixel access.
+    // Each output pixel maps to a clamped source coordinate, handling interior, strips and corners uniformly.
     private static Image<Rgba32> BuildPaddedBlock(Image<Rgba32> src, Rectangle srcRect, int padding)
     {
-        // Clamp crop
         int sx = Math.Clamp(srcRect.X, 0, Math.Max(0, src.Width - 1));
         int sy = Math.Clamp(srcRect.Y, 0, Math.Max(0, src.Height - 1));
         int sw = Math.Clamp(srcRect.Width, 1, src.Width - sx);
         int sh = Math.Clamp(srcRect.Height, 1, src.Height - sy);
 
-        using var crop = src.Clone(c => c.Crop(new Rectangle(sx, sy, sw, sh)));
-
         var block = new Image<Rgba32>(sw + 2 * padding, sh + 2 * padding);
 
-        // Paste interior at (p,p)
-        block.Mutate(c => c.DrawImage(crop, new Point(padding, padding), 1f));
-
-        if (padding <= 0) return block;
-
-        // Top / Bottom strips
-        using (var top = crop.Clone(c => c.Crop(new Rectangle(0, 0, sw, 1)).Resize(sw, padding)))
-            block.Mutate(c => c.DrawImage(top, new Point(padding, 0), 1f));
-        using (var bot = crop.Clone(c => c.Crop(new Rectangle(0, sh - 1, sw, 1)).Resize(sw, padding)))
-            block.Mutate(c => c.DrawImage(bot, new Point(padding, padding + sh), 1f));
-
-        // Left / Right strips
-        using (var left = crop.Clone(c => c.Crop(new Rectangle(0, 0, 1, sh)).Resize(padding, sh)))
-            block.Mutate(c => c.DrawImage(left, new Point(0, padding), 1f));
-        using (var right = crop.Clone(c => c.Crop(new Rectangle(sw - 1, 0, 1, sh)).Resize(padding, sh)))
-            block.Mutate(c => c.DrawImage(right, new Point(padding + sw, padding), 1f));
-
-        // Corners
-        void Corner(int sx0, int sy0, int dx, int dy)
+        src.ProcessPixelRows(block, (srcAcc, blockAcc) =>
         {
-            using var px = crop.Clone(c => c.Crop(new Rectangle(sx0, sy0, 1, 1)).Resize(padding, padding));
-            block.Mutate(c => c.DrawImage(px, new Point(dx, dy), 1f));
-        }
-        Corner(0, 0, 0, 0);
-        Corner(sw - 1, 0, padding + sw, 0);
-        Corner(0, sh - 1, 0, padding + sh);
-        Corner(sw - 1, sh - 1, padding + sw, padding + sh);
+            for (int destY = 0; destY < blockAcc.Height; destY++)
+            {
+                int srcY = Math.Clamp(destY - padding, 0, sh - 1) + sy;
+                var srcRow = srcAcc.GetRowSpan(srcY);
+                var destRow = blockAcc.GetRowSpan(destY);
+
+                for (int destX = 0; destX < blockAcc.Width; destX++)
+                {
+                    int srcX = Math.Clamp(destX - padding, 0, sw - 1) + sx;
+                    destRow[destX] = srcRow[srcX];
+                }
+            }
+        });
 
         return block;
     }

--- a/Obj2Tiles.Library/Geometry/MeshUtils.cs
+++ b/Obj2Tiles.Library/Geometry/MeshUtils.cs
@@ -178,9 +178,9 @@ public class MeshUtils
 
                     break;
                 }
-                case "mtllib" when segs.Length == 2:
+                case "mtllib" when segs.Length >= 2:
                 {
-                    var mtlFileName = segs[1];
+                    var mtlFileName = string.Join(" ", segs, 1, segs.Length - 1);
                     var mtlFilePath = Path.Combine(Path.GetDirectoryName(fileName) ?? string.Empty, mtlFileName);
 
                     var mats = Material.ReadMtl(mtlFilePath, out var mtlDeps, fileName);

--- a/Obj2Tiles.Library/Geometry/MeshUtils.cs
+++ b/Obj2Tiles.Library/Geometry/MeshUtils.cs
@@ -183,7 +183,7 @@ public class MeshUtils
                     var mtlFileName = segs[1];
                     var mtlFilePath = Path.Combine(Path.GetDirectoryName(fileName) ?? string.Empty, mtlFileName);
 
-                    var mats = Material.ReadMtl(mtlFilePath, out var mtlDeps);
+                    var mats = Material.ReadMtl(mtlFilePath, out var mtlDeps, fileName);
 
                     deps.AddRange(mtlDeps);
                     deps.Add(mtlFilePath);

--- a/Obj2Tiles.Library/Materials/Material.cs
+++ b/Obj2Tiles.Library/Materials/Material.cs
@@ -10,6 +10,79 @@ public class Material : ICloneable
     public string? Texture;
     public string? NormalMap;
 
+    private static readonly Dictionary<string, int> MtlOptionValueCounts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["-blendu"] = 1, ["-blendv"] = 1, ["-bm"] = 1, ["-boost"] = 1,
+        ["-cc"] = 1, ["-clamp"] = 1, ["-imfchan"] = 1, ["-mm"] = 2,
+        ["-texres"] = 1, ["-type"] = 1,
+        // -o, -s, -t take 1-3 numeric values and are handled separately
+    };
+
+    // Strips leading MTL option arguments (e.g. "-bm 1.0 -s 1 1") and returns
+    // the texture path at the end of the line, with separators normalized for the
+    // current platform. Handles paths that contain spaces.
+    private static string ExtractTexturePath(string lineRemainder)
+    {
+        var tokens = lineRemainder.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        int i = 0;
+        while (i < tokens.Length && tokens[i].StartsWith('-'))
+        {
+            var option = tokens[i];
+            i++;
+            if (option.Equals("-o", StringComparison.OrdinalIgnoreCase) ||
+                option.Equals("-s", StringComparison.OrdinalIgnoreCase) ||
+                option.Equals("-t", StringComparison.OrdinalIgnoreCase))
+            {
+                int consumed = 0;
+                while (i < tokens.Length && consumed < 3 &&
+                       double.TryParse(tokens[i], NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+                { i++; consumed++; }
+            }
+            else
+            {
+                MtlOptionValueCounts.TryGetValue(option, out var cnt);
+                if (cnt == 0) cnt = 1;
+                i = Math.Min(i + cnt, tokens.Length);
+            }
+        }
+        var raw = string.Join(' ', tokens[i..]);
+        return raw.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+    }
+
+    // Tries to locate a texture file by progressively relaxing the base directory.
+    // Returns the full absolute path on success, null if the file cannot be found.
+    private static string? ResolvePath(string path, string mtlFolder, string objFolder)
+    {
+        string candidate;
+
+        candidate = Path.GetFullPath(Path.Combine(mtlFolder, path));
+        if (File.Exists(candidate)) return candidate;
+
+        if (!string.Equals(mtlFolder, objFolder, StringComparison.OrdinalIgnoreCase))
+        {
+            candidate = Path.GetFullPath(Path.Combine(objFolder, path));
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        var fileName = Path.GetFileName(path);
+        if (fileName.Length < path.Length)
+        {
+            candidate = Path.GetFullPath(Path.Combine(mtlFolder, fileName));
+            if (File.Exists(candidate)) return candidate;
+
+            if (!string.Equals(mtlFolder, objFolder, StringComparison.OrdinalIgnoreCase))
+            {
+                candidate = Path.GetFullPath(Path.Combine(objFolder, fileName));
+                if (File.Exists(candidate)) return candidate;
+            }
+        }
+
+        candidate = Path.GetFullPath(path);
+        if (File.Exists(candidate)) return candidate;
+
+        return null;
+    }
+
     /// <summary>
     /// Ka - Ambient
     /// </summary>
@@ -52,7 +125,7 @@ public class Material : ICloneable
         IlluminationModel = illuminationModel;
     }
 
-    public static Material[] ReadMtl(string path, out string[] dependencies)
+    public static Material[] ReadMtl(string path, out string[] dependencies, string? objFilePath = null)
     {
         var lines = File.ReadAllLines(path);
         var materials = new List<Material>();
@@ -65,69 +138,89 @@ public class Material : ICloneable
         double? specularExponent = null, dissolve = null;
         IlluminationModel? illuminationModel = null;
 
+        var mtlFolder = Path.GetDirectoryName(Path.GetFullPath(path)) ?? string.Empty;
+        var objFolder = objFilePath != null
+            ? (Path.GetDirectoryName(Path.GetFullPath(objFilePath)) ?? string.Empty)
+            : mtlFolder;
+
         foreach (var line in lines)
         {
             if (line.StartsWith("#") || string.IsNullOrWhiteSpace(line))
                 continue;
 
             var lineTrimmed = line.Trim();
-            var parts = lineTrimmed.Split(' ');
-            switch (parts[0])
+            var spaceIdx = lineTrimmed.IndexOf(' ');
+            var keyword = spaceIdx >= 0 ? lineTrimmed[..spaceIdx] : lineTrimmed;
+            var remainder = spaceIdx >= 0 ? lineTrimmed[(spaceIdx + 1)..] : string.Empty;
+            var parts = remainder.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            switch (keyword)
             {
                 case "newmtl":
-
                     if (name.Length > 0)
                         materials.Add(new Material(name, texture, normalMap, ambientColor, diffuseColor, specularColor,
                             specularExponent, dissolve, illuminationModel));
 
-                    name = parts[1];
-
+                    name = remainder.Trim();
+                    texture = null;
+                    normalMap = null;
+                    ambientColor = null;
+                    diffuseColor = null;
+                    specularColor = null;
+                    specularExponent = null;
+                    dissolve = null;
+                    illuminationModel = null;
                     break;
+
                 case "map_Kd":
-                    texture = Path.IsPathRooted(parts[1])
-                        ? parts[1]
-                        : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(path)!, parts[1]));
-
-                    deps.Add(texture);
-
+                {
+                    var texPath = ExtractTexturePath(remainder);
+                    if (!string.IsNullOrEmpty(texPath))
+                    {
+                        texture = ResolvePath(texPath, mtlFolder, objFolder);
+                        if (texture != null) deps.Add(texture);
+                    }
                     break;
+                }
                 case "norm":
-                    normalMap = Path.IsPathRooted(parts[1])
-                        ? parts[1]
-                        : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(path)!, parts[1]));
-
-                    deps.Add(normalMap);
-
+                {
+                    var texPath = ExtractTexturePath(remainder);
+                    if (!string.IsNullOrEmpty(texPath))
+                    {
+                        normalMap = ResolvePath(texPath, mtlFolder, objFolder);
+                        if (normalMap != null) deps.Add(normalMap);
+                    }
                     break;
-                case "Ka":
+                }
+                case "Ka" when parts.Length >= 3:
                     ambientColor = new RGB(
+                        double.Parse(parts[0], CultureInfo.InvariantCulture),
                         double.Parse(parts[1], CultureInfo.InvariantCulture),
-                        double.Parse(parts[2], CultureInfo.InvariantCulture),
-                        double.Parse(parts[3], CultureInfo.InvariantCulture));
+                        double.Parse(parts[2], CultureInfo.InvariantCulture));
                     break;
-                case "Kd":
+                case "Kd" when parts.Length >= 3:
                     diffuseColor = new RGB(
+                        double.Parse(parts[0], CultureInfo.InvariantCulture),
                         double.Parse(parts[1], CultureInfo.InvariantCulture),
-                        double.Parse(parts[2], CultureInfo.InvariantCulture),
-                        double.Parse(parts[3], CultureInfo.InvariantCulture));
+                        double.Parse(parts[2], CultureInfo.InvariantCulture));
                     break;
-                case "Ks":
+                case "Ks" when parts.Length >= 3:
                     specularColor = new RGB(
+                        double.Parse(parts[0], CultureInfo.InvariantCulture),
                         double.Parse(parts[1], CultureInfo.InvariantCulture),
-                        double.Parse(parts[2], CultureInfo.InvariantCulture),
-                        double.Parse(parts[3], CultureInfo.InvariantCulture));
+                        double.Parse(parts[2], CultureInfo.InvariantCulture));
                     break;
-                case "Ns":
-                    specularExponent = double.Parse(parts[1], CultureInfo.InvariantCulture);
+                case "Ns" when parts.Length >= 1:
+                    specularExponent = double.Parse(parts[0], CultureInfo.InvariantCulture);
                     break;
-                case "d":
-                    dissolve = double.Parse(parts[1], CultureInfo.InvariantCulture);
+                case "d" when parts.Length >= 1:
+                    dissolve = double.Parse(parts[0], CultureInfo.InvariantCulture);
                     break;
-                case "Tr":
-                    dissolve = 1 - double.Parse(parts[1], CultureInfo.InvariantCulture);
+                case "Tr" when parts.Length >= 1:
+                    dissolve = 1 - double.Parse(parts[0], CultureInfo.InvariantCulture);
                     break;
-                case "illum":
-                    illuminationModel = (IlluminationModel)int.Parse(parts[1]);
+                case "illum" when parts.Length >= 1:
+                    illuminationModel = (IlluminationModel)int.Parse(parts[0]);
                     break;
                 default:
                     Debug.WriteLine($"Unknown line: '{line}'");

--- a/Obj2Tiles.Library/TexturesCache.cs
+++ b/Obj2Tiles.Library/TexturesCache.cs
@@ -6,26 +6,18 @@ namespace Obj2Tiles.Library;
 
 public static class TexturesCache
 {
-    private static readonly ConcurrentDictionary<string, Image<Rgba32>> Textures = new();
-    
+    private static readonly ConcurrentDictionary<string, Lazy<Image<Rgba32>>> Textures = new();
+
     public static Image<Rgba32> GetTexture(string textureName)
     {
-        if (Textures.TryGetValue(textureName, out var txout))
-            return txout;
-
-        var texture = Image.Load<Rgba32>(textureName);
-        Textures.TryAdd(textureName, texture);
-
-        return texture;
-
+        return Textures.GetOrAdd(textureName, p => new Lazy<Image<Rgba32>>(() => Image.Load<Rgba32>(p))).Value;
     }
-    
+
     public static void Clear()
     {
-        foreach(var texture in Textures)
-        {
-            texture.Value.Dispose();
-        }
+        foreach (var lazy in Textures.Values)
+            if (lazy.IsValueCreated)
+                lazy.Value.Dispose();
         Textures.Clear();
     }
 }

--- a/Obj2Tiles.Test/StagesTests.cs
+++ b/Obj2Tiles.Test/StagesTests.cs
@@ -360,4 +360,54 @@ public class StagesTests
 
     #endregion
 
+
+    #region Octree / PathTraversal
+
+    [Test]
+    public void TilingStage_Octree_BuildsParentChildHierarchy()
+    {
+        var testPath = GetTestOutputPath(nameof(TilingStage_Octree_BuildsParentChildHierarchy));
+        var src = Path.Combine(testPath, "src");
+        void Tri(string lod, string name)
+        {
+            var d = Path.Combine(src, lod);
+            Directory.CreateDirectory(d);
+            File.WriteAllText(Path.Combine(d, name + ".obj"), "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n");
+        }
+        Tri("LOD-0", "Mesh-XL-XR");
+        Tri("LOD-1", "Mesh-XL");
+
+        var lod0 = new Dictionary<string, Box3> { ["Mesh-XL-XR"] = new Box3(0, 0, 0, 1, 1, 1) };
+        var lod1 = new Dictionary<string, Box3> { ["Mesh-XL"] = new Box3(0, 0, 0, 2, 2, 2) };
+
+        StagesFacade.Tile(src, testPath, 2, 100, [lod0, lod1], localMode: true, isOctree: true);
+
+        var tileset = JsonConvert.DeserializeObject<Tileset>(File.ReadAllText(Path.Combine(testPath, "tileset.json")));
+        tileset!.Root!.Children.ShouldNotBeNull();
+        tileset.Root.Children!.Count.ShouldBe(1);
+        var coarse = tileset.Root.Children[0];
+        coarse.Content!.Uri.ShouldBe("LOD-1/Mesh-XL.b3dm");
+        coarse.Children.ShouldNotBeNull();
+        coarse.Children!.Count.ShouldBe(1);
+        coarse.Children[0].Content!.Uri.ShouldBe("LOD-0/Mesh-XL-XR.b3dm");
+    }
+
+    [Test]
+    public void CopyObjDependencies_PathTraversal_DoesNotEscapeOutput()
+    {
+        var testPath = GetTestOutputPath(nameof(CopyObjDependencies_PathTraversal_DoesNotEscapeOutput));
+        var inDir = Path.Combine(testPath, "in");
+        var outDir = Path.Combine(testPath, "out");
+        Directory.CreateDirectory(inDir);
+        Directory.CreateDirectory(outDir);
+        File.WriteAllText(Path.Combine(inDir, "evil.mtl"), "newmtl X\n");
+        File.WriteAllText(Path.Combine(inDir, "model.obj"), "mtllib ../evil.mtl\n");
+
+        Obj2Tiles.Utils.CopyObjDependencies(Path.Combine(inDir, "model.obj"), outDir);
+
+        File.Exists(Path.Combine(testPath, "evil.mtl")).ShouldBeFalse("traversal must not write outside output");
+    }
+
+    #endregion
+
 }

--- a/Obj2Tiles/Options.cs
+++ b/Obj2Tiles/Options.cs
@@ -59,6 +59,9 @@ public sealed class Options
 
     [Option("octree", Required = false, HelpText = "Use octree spatial subdivision: each LOD gets one additional division level relative to the next coarser LOD, producing a proper tile hierarchy instead of same-count tiles per LOD.", Default = false)]
     public bool Octree { get; set; }
+
+    [Option("lod-texture-scale", Required = false, HelpText = "Per-LOD texture downscale factor. LOD-0 always keeps full resolution; each subsequent LOD multiplies the previous resolution by this factor. E.g. 0.5 gives LOD-1 at 1/2 resolution, LOD-2 at 1/4, etc. Default 1.0 (no downscaling).", Default = 1.0)]
+    public double LodTextureScale { get; set; }
 }
 
 public enum Stage

--- a/Obj2Tiles/Options.cs
+++ b/Obj2Tiles/Options.cs
@@ -56,6 +56,9 @@ public sealed class Options
 
     [Option("local", Required = false, HelpText = "Local mode: no ECEF geo-referencing, uses identity matrix in tileset.json. Use this when you don't need to place the model on a globe.", Default = false)]
     public bool LocalMode { get; set; }
+
+    [Option("octree", Required = false, HelpText = "Use octree spatial subdivision: each LOD gets one additional division level relative to the next coarser LOD, producing a proper tile hierarchy instead of same-count tiles per LOD.", Default = false)]
+    public bool Octree { get; set; }
 }
 
 public enum Stage

--- a/Obj2Tiles/Program.cs
+++ b/Obj2Tiles/Program.cs
@@ -76,7 +76,7 @@ namespace Obj2Tiles
                 Console.WriteLine($" ?> Keep original textures: {opts.KeepOriginalTextures}, Split strategy: {opts.SplitPointStrategy}");
 
                 var boundsMapper = await StagesFacade.Split(decimateRes.DestFiles, destFolderSplit, opts.Divisions,
-                    opts.ZSplit, opts.KeepOriginalTextures, opts.SplitPointStrategy, opts.Octree);
+                    opts.ZSplit, opts.KeepOriginalTextures, opts.SplitPointStrategy, opts.Octree, (float)opts.LodTextureScale);
 
                 Console.WriteLine(" ?> Splitting stage done in {0}", sw.Elapsed);
 

--- a/Obj2Tiles/Program.cs
+++ b/Obj2Tiles/Program.cs
@@ -76,7 +76,7 @@ namespace Obj2Tiles
                 Console.WriteLine($" ?> Keep original textures: {opts.KeepOriginalTextures}, Split strategy: {opts.SplitPointStrategy}");
 
                 var boundsMapper = await StagesFacade.Split(decimateRes.DestFiles, destFolderSplit, opts.Divisions,
-                    opts.ZSplit, opts.KeepOriginalTextures, opts.SplitPointStrategy);
+                    opts.ZSplit, opts.KeepOriginalTextures, opts.SplitPointStrategy, opts.Octree);
 
                 Console.WriteLine(" ?> Splitting stage done in {0}", sw.Elapsed);
 
@@ -100,7 +100,7 @@ namespace Obj2Tiles
                 if (opts.LocalMode && (opts.Latitude != null || opts.Longitude != null))
                     Console.WriteLine(" !> Warning: --local overrides --lat/--lon. ECEF transform will not be applied.");
 
-                StagesFacade.Tile(destFolderSplit, opts.Output, opts.LODs, opts.BaseError, boundsMapper, gpsCoords, opts.LocalMode);
+                StagesFacade.Tile(destFolderSplit, opts.Output, opts.LODs, opts.BaseError, boundsMapper, gpsCoords, opts.LocalMode, opts.Octree);
 
                 Console.WriteLine(" ?> Tiling stage done in {0}", sw.Elapsed);
             }

--- a/Obj2Tiles/Stages/SplitStage.cs
+++ b/Obj2Tiles/Stages/SplitStage.cs
@@ -9,7 +9,7 @@ public static partial class StagesFacade
 {
     public static async Task<Dictionary<string, Box3>[]> Split(string[] sourceFiles, string destFolder, int divisions,
         bool zsplit, bool keepOriginalTextures = false, SplitPointStrategy splitPointStrategy = SplitPointStrategy.VertexBaricenter,
-        bool isOctree = false)
+        bool isOctree = false, float lodTextureScale = 1.0f)
     {
         var results = new Dictionary<string, Box3>[sourceFiles.Length];
 
@@ -74,8 +74,9 @@ public static partial class StagesFacade
                 index == 0 ? TexturesStrategy.Repack : TexturesStrategy.RepackCompressed;
 
             int lodDivisions = isOctree ? divisions + sourceFiles.Length - index - 1 : divisions;
+            float textureDownscale = index == 0 ? 1.0f : (float)Math.Pow(lodTextureScale, index);
 
-            tasks.Add(Split(file, dest, lodDivisions, zsplit, textureStrategy, splitPointStrategy, replaySplitPoint));
+            tasks.Add(Split(file, dest, lodDivisions, zsplit, textureStrategy, splitPointStrategy, replaySplitPoint, textureDownscale));
         }
 
         await Task.WhenAll(tasks);
@@ -107,7 +108,8 @@ public static partial class StagesFacade
         bool zSplit,
         TexturesStrategy textureStrategy,
         SplitPointStrategy splitPointStrategy,
-        Func<IMesh, Vertex3> getSplitPoint)
+        Func<IMesh, Vertex3> getSplitPoint,
+        float textureDownscale = 1.0f)
     {
         var sw = new Stopwatch();
         var tilesBounds = new Dictionary<string, Box3>();
@@ -170,7 +172,10 @@ public static partial class StagesFacade
         foreach (var m in ms)
         {
             if (m is MeshT t)
+            {
                 t.TexturesStrategy = textureStrategy;
+                t.TextureDownscale = textureDownscale;
+            }
 
             m.WriteObj(Path.Combine(destPath, $"{m.Name}.obj"));
 

--- a/Obj2Tiles/Stages/SplitStage.cs
+++ b/Obj2Tiles/Stages/SplitStage.cs
@@ -165,22 +165,38 @@ public static partial class StagesFacade
             $" ?> Done {count} edge splits in {sw.ElapsedMilliseconds}ms ({(double)count / sw.ElapsedMilliseconds:F2} split/ms)");
 
         Console.WriteLine(" -> Writing tiles");
+        Console.WriteLine($" ?> Destination: {destPath}");
+        Console.WriteLine($" ?> Texture strategy: {textureStrategy}, Texture downscale: {textureDownscale:F3}");
 
         sw.Restart();
 
         var ms = meshes.ToArray();
-        foreach (var m in ms)
+        var boundsMap = new ConcurrentDictionary<string, Box3>();
+        var progress = 0;
+        var lodName = Path.GetFileName(destPath);
+
+        Parallel.ForEach(ms, m =>
         {
+            var n = Interlocked.Increment(ref progress);
+            m.DebugName = $"{lodName}-Mesh-{n}/{ms.Length}";
+
             if (m is MeshT t)
             {
                 t.TexturesStrategy = textureStrategy;
                 t.TextureDownscale = textureDownscale;
             }
 
-            m.WriteObj(Path.Combine(destPath, $"{m.Name}.obj"));
+            var tilePath = Path.Combine(destPath, $"{m.Name}.obj");
+            var tileStart = sw.ElapsedMilliseconds;
+            Console.WriteLine($" -> [{m.DebugName}] Writing Tile '{m.Name}' ({m.VertexCount}v, {m.FacesCount}f)");
+            m.WriteObj(tilePath);
+            Console.WriteLine($" ?> [{m.DebugName}] Done in {sw.ElapsedMilliseconds - tileStart}ms");
 
-            tilesBounds.Add(m.Name, m.Bounds);
-        }
+            boundsMap[m.Name] = m.Bounds;
+        });
+
+        foreach (var kv in boundsMap)
+            tilesBounds.Add(kv.Key, kv.Value);
 
         Console.WriteLine($" ?> {meshes.Count} tiles written in {sw.ElapsedMilliseconds}ms");
 

--- a/Obj2Tiles/Stages/SplitStage.cs
+++ b/Obj2Tiles/Stages/SplitStage.cs
@@ -8,9 +8,13 @@ namespace Obj2Tiles.Stages;
 public static partial class StagesFacade
 {
     public static async Task<Dictionary<string, Box3>[]> Split(string[] sourceFiles, string destFolder, int divisions,
-        bool zsplit, bool keepOriginalTextures = false, SplitPointStrategy splitPointStrategy = SplitPointStrategy.VertexBaricenter)
+        bool zsplit, bool keepOriginalTextures = false, SplitPointStrategy splitPointStrategy = SplitPointStrategy.VertexBaricenter,
+        bool isOctree = false)
     {
         var results = new Dictionary<string, Box3>[sourceFiles.Length];
+
+        // In octree mode, LOD-0 (finest) gets the most divisions; the split plan must cover that maximum depth.
+        int maxDivisions = isOctree ? divisions + sourceFiles.Length - 1 : divisions;
 
         // Pre-compute split plan from LOD-0 vertices (lightweight — no mesh splitting, just vertex partitioning)
         Console.WriteLine(" -> Pre-computing split plan from LOD-0 vertices");
@@ -31,16 +35,16 @@ public static partial class StagesFacade
         if (splitPointStrategy == SplitPointStrategy.VertexMedian)
         {
             if (zsplit)
-                PreComputeSplitPlanXYZBalanced(vertices0, "Mesh", divisions, computeCenter, splitPlan);
+                PreComputeSplitPlanXYZBalanced(vertices0, "Mesh", maxDivisions, computeCenter, splitPlan);
             else
-                PreComputeSplitPlanXYBalanced(vertices0, "Mesh", divisions, computeCenter, splitPlan);
+                PreComputeSplitPlanXYBalanced(vertices0, "Mesh", maxDivisions, computeCenter, splitPlan);
         }
         else
         {
             if (zsplit)
-                PreComputeSplitPlanXYZ(vertices0, "Mesh", divisions, computeCenter, splitPlan);
+                PreComputeSplitPlanXYZ(vertices0, "Mesh", maxDivisions, computeCenter, splitPlan);
             else
-                PreComputeSplitPlanXY(vertices0, "Mesh", divisions, computeCenter, splitPlan);
+                PreComputeSplitPlanXY(vertices0, "Mesh", maxDivisions, computeCenter, splitPlan);
         }
 
         sw.Stop();
@@ -58,7 +62,8 @@ public static partial class StagesFacade
         Func<IMesh, Vertex3> replaySplitPoint = m =>
             splitPlan.TryGetValue(m.Name, out var pt) ? pt : baseSplitPoint(m);
 
-        // Split all LODs in parallel using the pre-computed split plan
+        // Split all LODs in parallel using the pre-computed split plan.
+        // In octree mode, the finest LOD (index=0) gets the most divisions; each coarser LOD gets one fewer.
         var tasks = new List<Task<Dictionary<string, Box3>>>();
         for (var index = 0; index < sourceFiles.Length; index++)
         {
@@ -68,7 +73,9 @@ public static partial class StagesFacade
             var textureStrategy = keepOriginalTextures ? TexturesStrategy.KeepOriginal :
                 index == 0 ? TexturesStrategy.Repack : TexturesStrategy.RepackCompressed;
 
-            tasks.Add(Split(file, dest, divisions, zsplit, textureStrategy, splitPointStrategy, replaySplitPoint));
+            int lodDivisions = isOctree ? divisions + sourceFiles.Length - index - 1 : divisions;
+
+            tasks.Add(Split(file, dest, lodDivisions, zsplit, textureStrategy, splitPointStrategy, replaySplitPoint));
         }
 
         await Task.WhenAll(tasks);

--- a/Obj2Tiles/Stages/TilingStage.cs
+++ b/Obj2Tiles/Stages/TilingStage.cs
@@ -12,7 +12,7 @@ namespace Obj2Tiles.Stages;
 public static partial class StagesFacade
 {
     public static void Tile(string sourcePath, string destPath, int lods, double baseError, Dictionary<string, Box3>[] boundsMapper,
-        GpsCoords? coords = null, bool localMode = false)
+        GpsCoords? coords = null, bool localMode = false, bool isOctree = false)
     {
 
         Console.WriteLine(" ?> Working on objs conversion");
@@ -64,50 +64,106 @@ public static partial class StagesFacade
         var maxZ = double.MinValue;
         var minZ = double.MaxValue;
 
-        var masterDescriptors = boundsMapper[0].Keys;
-
-        foreach (var descriptor in masterDescriptors)
+        if (isOctree)
         {
-            var currentTileElement = tileset.Root;
+            // Build a parent lookup: for each tile in a finer LOD, find its parent in the next coarser LOD.
+            // Tile names are hierarchical (e.g. "Mesh-XL-YL-XR-YR"), so a tile is a child of any coarser tile
+            // whose name is a strict prefix (key + "-") of the tile's name.
+            var lodParentMap = new Dictionary<string, string>();
+            for (var lod = 0; lod < lods - 1; lod++)
+            {
+                foreach (var fineKey in boundsMapper[lod].Keys)
+                {
+                    // Walk coarser LODs to find the immediate parent
+                    var parent = boundsMapper[lod + 1].Keys
+                        .FirstOrDefault(coarseKey => fineKey.StartsWith(coarseKey + "-"));
+                    if (parent != null)
+                        lodParentMap[fineKey] = parent;
+                }
+            }
 
-            var refBox = boundsMapper[0][descriptor];
+            // Tile element cache so children can be appended when we reach finer LODs
+            var tileMap = new Dictionary<string, TileElement>();
 
+            // Process coarsest → finest so parents exist in tileMap before their children are added
             for (var lod = lods - 1; lod >= 0; lod--)
             {
-                if (!boundsMapper[lod].TryGetValue(descriptor, out var box3)) continue;
-
-                if (box3.Min.X < minX)
-                    minX = box3.Min.X;
-
-                if (box3.Max.X > maxX)
-                    maxX = box3.Max.X;
-
-                if (box3.Min.Y < minY)
-                    minY = box3.Min.Y;
-
-                if (box3.Max.Y > maxY)
-                    maxY = box3.Max.Y;
-
-                if (box3.Min.Z < minZ)
-                    minZ = box3.Min.Z;
-
-                if (box3.Max.Z > maxZ)
-                    maxZ = box3.Max.Z;
-
-                var tile = new TileElement
+                foreach (var (descriptor, box3) in boundsMapper[lod])
                 {
-                    GeometricError = lod == 0 ? 0 : CalculateGeometricError(refBox, box3, lod),
-                    Refine = "REPLACE",
-                    Content = new Content
-                    {
-                        Uri = $"LOD-{lod}/{Path.GetFileNameWithoutExtension(descriptor)}.b3dm"
-                    },
-                    BoundingVolume = box3.ToBoundingVolume()
-                };
+                    if (box3.Min.X < minX) minX = box3.Min.X;
+                    if (box3.Max.X > maxX) maxX = box3.Max.X;
+                    if (box3.Min.Y < minY) minY = box3.Min.Y;
+                    if (box3.Max.Y > maxY) maxY = box3.Max.Y;
+                    if (box3.Min.Z < minZ) minZ = box3.Min.Z;
+                    if (box3.Max.Z > maxZ) maxZ = box3.Max.Z;
 
-                currentTileElement.Children ??= [];
-                currentTileElement.Children.Add(tile);
-                currentTileElement = tile;
+                    var tile = new TileElement
+                    {
+                        // Coarser tiles have larger geometric error (seen from farther away);
+                        // finest tiles are leaves with error = 0.
+                        GeometricError = lod == 0 ? 0 : baseError / Math.Pow(2, lods - lod),
+                        Refine = "REPLACE",
+                        Content = new Content
+                        {
+                            Uri = $"LOD-{lod}/{Path.GetFileNameWithoutExtension(descriptor)}.b3dm"
+                        },
+                        BoundingVolume = box3.ToBoundingVolume()
+                    };
+
+                    tileMap[descriptor] = tile;
+
+                    if (lodParentMap.TryGetValue(descriptor, out var parentKey))
+                    {
+                        tileMap[parentKey].Children ??= [];
+                        tileMap[parentKey].Children!.Add(tile);
+                    }
+                    else
+                    {
+                        // No parent in a coarser LOD — attach directly to the root
+                        tileset.Root!.Children ??= [];
+                        tileset.Root!.Children!.Add(tile);
+                    }
+                }
+            }
+        }
+        else
+        {
+            // Standard mode: all LODs produce the same set of tiles; each descriptor maps to a chain
+            // LOD-(n-1) → LOD-(n-2) → ... → LOD-0 hanging from the root via REPLACE refinement.
+            var masterDescriptors = boundsMapper[0].Keys;
+
+            foreach (var descriptor in masterDescriptors)
+            {
+                var currentTileElement = tileset.Root;
+
+                var refBox = boundsMapper[0][descriptor];
+
+                for (var lod = lods - 1; lod >= 0; lod--)
+                {
+                    if (!boundsMapper[lod].TryGetValue(descriptor, out var box3)) continue;
+
+                    if (box3.Min.X < minX) minX = box3.Min.X;
+                    if (box3.Max.X > maxX) maxX = box3.Max.X;
+                    if (box3.Min.Y < minY) minY = box3.Min.Y;
+                    if (box3.Max.Y > maxY) maxY = box3.Max.Y;
+                    if (box3.Min.Z < minZ) minZ = box3.Min.Z;
+                    if (box3.Max.Z > maxZ) maxZ = box3.Max.Z;
+
+                    var tile = new TileElement
+                    {
+                        GeometricError = lod == 0 ? 0 : CalculateGeometricError(refBox, box3, lod),
+                        Refine = "REPLACE",
+                        Content = new Content
+                        {
+                            Uri = $"LOD-{lod}/{Path.GetFileNameWithoutExtension(descriptor)}.b3dm"
+                        },
+                        BoundingVolume = box3.ToBoundingVolume()
+                    };
+
+                    currentTileElement.Children ??= [];
+                    currentTileElement.Children.Add(tile);
+                    currentTileElement = tile;
+                }
             }
         }
 

--- a/Obj2Tiles/Stages/TilingStage.cs
+++ b/Obj2Tiles/Stages/TilingStage.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Text;
 using Newtonsoft.Json;
 using Obj2Tiles.Library.Geometry;
@@ -74,7 +74,7 @@ public static partial class StagesFacade
             {
                 foreach (var fineKey in boundsMapper[lod].Keys)
                 {
-                    // Walk coarser LODs to find the immediate parent
+                    // Each LOD differs from the next by exactly one split level, so the parent is the single coarser tile whose name is a strict prefix
                     var parent = boundsMapper[lod + 1].Keys
                         .FirstOrDefault(coarseKey => fineKey.StartsWith(coarseKey + "-"));
                     if (parent != null)

--- a/Obj2Tiles/Utils.cs
+++ b/Obj2Tiles/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 using Obj2Tiles.Library.Geometry;
 using Obj2Tiles.Stages.Model;
 using Obj2Tiles.Tiles;
@@ -8,110 +9,152 @@ namespace Obj2Tiles;
 
 public static class Utils
 {
-    public static IEnumerable<string> GetObjDependencies(string objPath)
+    private static readonly string[] MtlMapKeywords =
     {
-        var objFile = File.ReadAllLines(objPath);
+        "map_Kd", "map_Ka", "map_Ks", "map_Bump", "map_d", "map_Ns",
+        "norm", "bump", "disp", "decal"
+    };
 
-        var dependencies = new List<string>();
-
-        var folderName = Path.GetDirectoryName(objPath);
-
-        foreach (var line in objFile)
+    private static readonly Dictionary<string, int> MtlOptionValueCounts =
+        new(StringComparer.OrdinalIgnoreCase)
         {
-            var trimmedLine = line.Trim();
+            ["-blendu"] = 1, ["-blendv"] = 1, ["-bm"] = 1, ["-boost"] = 1,
+            ["-cc"] = 1, ["-clamp"] = 1, ["-imfchan"] = 1, ["-mm"] = 2,
+            ["-texres"] = 1, ["-type"] = 1,
+            // -o, -s, -t take 1-3 numeric values and are handled separately
+        };
 
-            if (!trimmedLine.StartsWith("mtllib")) continue;
-
-            var mtlPath = folderName != null ? Path.Combine(folderName, trimmedLine[7..].Trim()) : trimmedLine[7..].Trim();
-            
-            dependencies.Add(trimmedLine[7..].Trim());
-
-            dependencies.AddRange(GetMtlDependencies(mtlPath));
+    // Strips leading MTL option arguments (e.g. "-bm 1.0 -s 1 1") and returns
+    // the texture path with separators normalized for the current platform.
+    private static string ExtractTexturePath(string lineRemainder)
+    {
+        var tokens = lineRemainder.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        int i = 0;
+        while (i < tokens.Length && tokens[i].StartsWith('-'))
+        {
+            var option = tokens[i];
+            i++;
+            if (option.Equals("-o", StringComparison.OrdinalIgnoreCase) ||
+                option.Equals("-s", StringComparison.OrdinalIgnoreCase) ||
+                option.Equals("-t", StringComparison.OrdinalIgnoreCase))
+            {
+                int consumed = 0;
+                while (i < tokens.Length && consumed < 3 &&
+                       double.TryParse(tokens[i], NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+                { i++; consumed++; }
+            }
+            else
+            {
+                MtlOptionValueCounts.TryGetValue(option, out var cnt);
+                if (cnt == 0) cnt = 1;
+                i = Math.Min(i + cnt, tokens.Length);
+            }
         }
-
-        return dependencies;
+        var raw = string.Join(' ', tokens[i..]);
+        return raw.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
     }
 
-    private static List<string> GetMtlDependencies(string mtlPath)
+    // Tries to locate a file by progressively relaxing the base directory.
+    // Returns the resolved absolute path, or null if no candidate exists.
+    private static string? ResolveTexturePath(string path, string mtlFolder, string objFolder)
     {
-        var mtlFile = File.ReadAllLines(mtlPath);
+        string candidate;
 
-        var dependencies = new List<string>();
-        
-        foreach (var line in mtlFile)
+        candidate = Path.GetFullPath(Path.Combine(mtlFolder, path));
+        if (File.Exists(candidate)) return candidate;
+
+        if (!string.Equals(mtlFolder, objFolder, StringComparison.OrdinalIgnoreCase))
         {
-            
+            candidate = Path.GetFullPath(Path.Combine(objFolder, path));
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        var fileName = Path.GetFileName(path);
+        if (fileName.Length < path.Length)
+        {
+            candidate = Path.GetFullPath(Path.Combine(mtlFolder, fileName));
+            if (File.Exists(candidate)) return candidate;
+
+            if (!string.Equals(mtlFolder, objFolder, StringComparison.OrdinalIgnoreCase))
+            {
+                candidate = Path.GetFullPath(Path.Combine(objFolder, fileName));
+                if (File.Exists(candidate)) return candidate;
+            }
+        }
+
+        candidate = Path.GetFullPath(path);
+        if (File.Exists(candidate)) return candidate;
+
+        return null;
+    }
+
+    // Returns (normalizedRelPath, resolvedAbsPath) pairs for every texture
+    // referenced by an MTL file. Uses the full resolution algorithm.
+    private static IEnumerable<(string relPath, string resolvedPath)> GetMtlTextureDependencies(
+        string mtlPath, string objFolder)
+    {
+        if (!File.Exists(mtlPath)) yield break;
+
+        var mtlFolder = Path.GetDirectoryName(Path.GetFullPath(mtlPath)) ?? string.Empty;
+
+        foreach (var line in File.ReadAllLines(mtlPath))
+        {
             var trimmedLine = line.Trim();
-            
-            if (trimmedLine.StartsWith("map_Kd"))
+            if (string.IsNullOrEmpty(trimmedLine) || trimmedLine.StartsWith('#')) continue;
+
+            foreach (var keyword in MtlMapKeywords)
             {
-                dependencies.Add(trimmedLine[7..].Trim());
+                if (!trimmedLine.StartsWith(keyword, StringComparison.OrdinalIgnoreCase)) continue;
+                // Reject prefix matches like "map_Kd2" for "map_Kd"
+                if (trimmedLine.Length > keyword.Length &&
+                    trimmedLine[keyword.Length] != ' ' && trimmedLine[keyword.Length] != '\t') continue;
 
-                continue;
+                var remainder = trimmedLine.Length > keyword.Length
+                    ? trimmedLine[(keyword.Length + 1)..]
+                    : string.Empty;
+
+                var texPath = ExtractTexturePath(remainder);
+                if (string.IsNullOrWhiteSpace(texPath)) break;
+
+                if (Path.IsPathRooted(texPath))
+                {
+                    Debug.WriteLine($" ?> Skipping rooted MTL dependency: {texPath}");
+                    break;
+                }
+
+                var resolved = ResolveTexturePath(texPath, mtlFolder, objFolder);
+                if (resolved != null)
+                    yield return (texPath, resolved);
+                else
+                    Debug.WriteLine($" ?> Could not resolve MTL dependency: {texPath}");
+
+                break;
             }
+        }
+    }
 
-            if (trimmedLine.StartsWith("map_Ka"))
-            {
-                dependencies.Add(trimmedLine[7..].Trim());
+    // Returns the normalized relative paths of all files that the OBJ depends on
+    // (the MTL itself plus every texture it references).
+    public static IEnumerable<string> GetObjDependencies(string objPath)
+    {
+        var objFolder = Path.GetDirectoryName(Path.GetFullPath(objPath)) ?? string.Empty;
+        var dependencies = new List<string>();
 
-                continue;
-            }
+        foreach (var line in File.ReadAllLines(objPath))
+        {
+            var trimmedLine = line.Trim();
+            if (!trimmedLine.StartsWith("mtllib")) continue;
+            if (trimmedLine.Length <= 6 || (trimmedLine[6] != ' ' && trimmedLine[6] != '\t')) continue;
 
-            if (trimmedLine.StartsWith("norm"))
-            {
-                dependencies.Add(trimmedLine[5..].Trim());
+            var mtlRelPath = trimmedLine[7..].Trim()
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar);
 
-                continue;
-            }
+            dependencies.Add(mtlRelPath);
 
-            if (trimmedLine.StartsWith("map_Ks"))
-            {
-                dependencies.Add(trimmedLine[7..].Trim());
-
-                continue;
-            }
-
-            if (trimmedLine.StartsWith("map_Bump"))
-            {
-                dependencies.Add(trimmedLine[8..].Trim());
-
-                continue;
-            }
-
-            if (trimmedLine.StartsWith("map_d"))
-            {
-                dependencies.Add(trimmedLine[6..].Trim());
-
-                continue;
-            }
-
-            if (trimmedLine.StartsWith("map_Ns"))
-            {
-                dependencies.Add(trimmedLine[7..].Trim());
-
-                continue;
-            }
-
-            if (trimmedLine.StartsWith("bump"))
-            {
-                dependencies.Add(trimmedLine[5..].Trim());
-
-                continue;
-            }
-
-            if (trimmedLine.StartsWith("disp"))
-            {
-                dependencies.Add(trimmedLine[5..].Trim());
-
-                continue;
-            }
-
-            if (trimmedLine.StartsWith("decal"))
-            {
-                dependencies.Add(trimmedLine[6..].Trim());
-
-                continue;
-            }
+            var mtlAbsPath = Path.Combine(objFolder, mtlRelPath);
+            foreach (var (relPath, _) in GetMtlTextureDependencies(mtlAbsPath, objFolder))
+                dependencies.Add(relPath);
         }
 
         return dependencies;
@@ -133,29 +176,40 @@ public static class Utils
     
     public static void CopyObjDependencies(string input, string output)
     {
-        var dependencies = GetObjDependencies(input);
+        var objFolder = Path.GetDirectoryName(Path.GetFullPath(input)) ?? string.Empty;
 
-        foreach (var dependency in dependencies)
+        foreach (var line in File.ReadAllLines(input))
         {
-            if (Path.IsPathRooted(dependency))
+            var trimmedLine = line.Trim();
+            if (!trimmedLine.StartsWith("mtllib")) continue;
+            if (trimmedLine.Length <= 6 || (trimmedLine[6] != ' ' && trimmedLine[6] != '\t')) continue;
+
+            var mtlRelPath = trimmedLine[7..].Trim()
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar);
+
+            var mtlSrcPath = Path.Combine(objFolder, mtlRelPath);
+            var mtlDestPath = Path.Combine(output, mtlRelPath);
+            var mtlDestFolder = Path.GetDirectoryName(mtlDestPath);
+            if (mtlDestFolder != null) Directory.CreateDirectory(mtlDestFolder);
+
+            if (!File.Exists(mtlDestPath) && File.Exists(mtlSrcPath))
             {
-                Debug.WriteLine(" ?> Cannot copy dependency because the path is rooted");
-                continue;
+                File.Copy(mtlSrcPath, mtlDestPath, true);
+                Console.WriteLine($" -> Copied {mtlRelPath}");
             }
 
-            var dependencyDestPath = Path.Combine(output, dependency);
+            foreach (var (relPath, absPath) in GetMtlTextureDependencies(mtlSrcPath, objFolder))
+            {
+                var texDestPath = Path.Combine(output, relPath);
+                var texDestFolder = Path.GetDirectoryName(texDestPath);
+                if (texDestFolder != null) Directory.CreateDirectory(texDestFolder);
 
-            var destFolder = Path.GetDirectoryName(dependencyDestPath);
-            if (destFolder != null) Directory.CreateDirectory(destFolder);
+                if (File.Exists(texDestPath)) continue;
 
-            if (File.Exists(dependencyDestPath))
-                continue;
-
-            var directoryName = Path.GetDirectoryName(input) ?? string.Empty;
-
-            File.Copy(Path.Combine(directoryName, dependency), dependencyDestPath, true);
-
-            Console.WriteLine($" -> Copied {dependency}");
+                File.Copy(absPath, texDestPath, true);
+                Console.WriteLine($" -> Copied {relPath}");
+            }
         }
     }
     

--- a/Obj2Tiles/Utils.cs
+++ b/Obj2Tiles/Utils.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Globalization;
 using Obj2Tiles.Library.Geometry;
 using Obj2Tiles.Stages.Model;
@@ -177,6 +177,7 @@ public static class Utils
     public static void CopyObjDependencies(string input, string output)
     {
         var objFolder = Path.GetDirectoryName(Path.GetFullPath(input)) ?? string.Empty;
+        var outputFull = Path.GetFullPath(output).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
         foreach (var line in File.ReadAllLines(input))
         {
@@ -190,6 +191,11 @@ public static class Utils
 
             var mtlSrcPath = Path.Combine(objFolder, mtlRelPath);
             var mtlDestPath = Path.Combine(output, mtlRelPath);
+            if (!IsWithinOutput(outputFull, mtlDestPath))
+            {
+                Debug.WriteLine($" ?> Skipping MTL outside output folder: {mtlRelPath}");
+                continue;
+            }
             var mtlDestFolder = Path.GetDirectoryName(mtlDestPath);
             if (mtlDestFolder != null) Directory.CreateDirectory(mtlDestFolder);
 
@@ -202,6 +208,11 @@ public static class Utils
             foreach (var (relPath, absPath) in GetMtlTextureDependencies(mtlSrcPath, objFolder))
             {
                 var texDestPath = Path.Combine(output, relPath);
+                if (!IsWithinOutput(outputFull, texDestPath))
+                {
+                    Debug.WriteLine($" ?> Skipping texture outside output folder: {relPath}");
+                    continue;
+                }
                 var texDestFolder = Path.GetDirectoryName(texDestPath);
                 if (texDestFolder != null) Directory.CreateDirectory(texDestFolder);
 
@@ -213,6 +224,14 @@ public static class Utils
         }
     }
     
+    // Guards against path traversal: ensures destPath resolves inside the output folder.
+    private static bool IsWithinOutput(string outputFull, string destPath)
+    {
+        var full = Path.GetFullPath(destPath);
+        return full == outputFull ||
+               full.StartsWith(outputFull + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+    }
+
     public static void ConvertB3dm(string objPath, string destPath)
     {
         var dir = Path.GetDirectoryName(objPath);

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ You can download precompiled binaries for Windows, Linux and macOS from https://
   --scale                (Default: 1), scale factor for local geometry (e.g. 1200.0/3937.0 for survey ft). Does NOT affect altitude or ECEF position.
   --local                (Default: false) Local mode: no ECEF geo-referencing, uses identity matrix. Use this when you don't need globe placement.
 
+  --octree               (Default: false) Use octree spatial subdivision. Each LOD receives one additional
+                         division level relative to the next coarser LOD, so the tile count increases with
+                         detail. Produces a proper parent-child tile hierarchy in tileset.json instead of
+                         the default same-count-per-LOD chains. Use together with --zsplit for a true octree.
+
+  --lod-texture-scale    (Default: 1.0) Per-LOD texture downscale factor applied cumulatively to each LOD
+                         after LOD-0. LOD-0 always keeps full resolution. Each subsequent LOD multiplies
+                         the previous atlas resolution by this factor. For example, 0.5 gives LOD-1 at
+                         half resolution, LOD-2 at quarter resolution, etc.
+
   --y-up-to-z-up         (Default: false) Converts Y-up to Z-up
 
   --use-system-temp      (Default: false) Uses the system temp folder
@@ -50,6 +60,13 @@ You can download precompiled binaries for Windows, Linux and macOS from https://
 
   --help                 Display this help screen.
   --version              Display version information.
+```
+
+
+A nice sample commandline is:
+
+```
+Obj2Tiles --lod-texture-scale 0.5 --octree --local --zsplit --lods 3 my.obj my-tileset
 ```
 
 The pipeline is composed of the following steps:
@@ -78,6 +95,30 @@ The `--split-strategy` flag controls how the split point is determined at each r
 
 - **`VertexBaricenter`** (default): the split point is the barycenter of the vertices of the current sub-mesh. This produces tiles that are more balanced in terms of vertex/face count, because the cut plane adapts to where the geometry is actually concentrated.
 - **`AbsoluteCenter`**: the split point is the geometric center of the bounding box. This produces a spatially uniform grid, which is more predictable and reproducible but can result in uneven tiles when the geometry is not uniformly distributed.
+
+#### Octree mode (`--octree`)
+
+By default every LOD produces the same number of tiles, which are then arranged as per-tile chains in `tileset.json`. With `--octree`, each LOD receives one additional division level compared to the next coarser LOD:
+
+| LOD | Divisions (default `--divisions 2`, 3 LODs) | Tiles (XY) |
+|-----|---------------------------------------------|------------|
+| 0 (finest) | 4 | 256 |
+| 1 | 3 | 64 |
+| 2 (coarsest) | 2 | 16 |
+
+The coarser tiles become spatial parents of the finer ones in `tileset.json`, producing a proper tree hierarchy where a viewer progressively refines tiles as the camera moves closer. Use `--octree` together with `--zsplit` to get a true 8-way octree (each tile splits into 8 children).
+
+#### Texture downscaling (`--lod-texture-scale`)
+
+Each tile's texture atlas is repacked from the portion of the source texture that falls within that tile. By default every LOD receives an atlas at the same pixel resolution. Use `--lod-texture-scale` to reduce atlas resolution for coarser LODs, which are only ever seen from a distance:
+
+| LOD | Scale (`--lod-texture-scale 0.5`) | Example atlas (4096×4096 source, 16 tiles) |
+|-----|------------------------------------|--------------------------------------------|
+| 0 (finest) | 1.0 (always full) | 1024×1024 PNG |
+| 1 | 0.5 | 512×512 JPEG |
+| 2 | 0.25 | 256×256 JPEG |
+
+The downscaling uses bicubic resampling. LOD-0 is always saved as PNG; coarser LODs are saved as JPEG at quality 75.
 
 ### 3D Tiles conversion
 
@@ -158,6 +199,14 @@ If you don't need to place the model on a globe (e.g., for a local 3D viewer), u
 
 ```
 Obj2Tiles --local model.obj ./output
+```
+
+### Octree with texture downscaling
+
+Produce a proper octree hierarchy where coarser LODs cover larger areas and finer LODs refine them, with textures halved at each LOD step:
+
+```
+Obj2Tiles --octree --zsplit --lods 3 --divisions 2 --lod-texture-scale 0.5 --local model.obj ./output
 ```
 
 ## Rotating the model


### PR DESCRIPTION
Add the support for the octree algorithm (based on ideas from Dušan Knežević).
Support texture downscaling at coarser LODs - saves a lot of memory and improves performance.
Improve material file parsing when textures are in folders or use strange names.
Parallelize tile writing.
Some small algorithmic performance improvements.
