### PR TITLE
Add opt-in contentless tileset root

### DIFF
--- a/Obj2Tiles.Test/OptionsTests.cs
+++ b/Obj2Tiles.Test/OptionsTests.cs
@@ -1,0 +1,30 @@
+using CommandLine;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Obj2Tiles.Test;
+
+public class OptionsTests
+{
+    [Test]
+    public void NoRootContent_DefaultsToFalse()
+    {
+        Parse("input.obj", "output").NoRootContent.ShouldBeFalse();
+    }
+
+    [Test]
+    public void NoRootContent_ParsesFlag()
+    {
+        Parse("--no-root-content", "input.obj", "output").NoRootContent.ShouldBeTrue();
+    }
+
+    private static Options Parse(params string[] args)
+    {
+        Options? options = null;
+        using var parser = new Parser(settings => settings.HelpWriter = null);
+        var result = parser.ParseArguments<Options>(args);
+        result.WithParsed(parsed => options = parsed);
+        result.Tag.ShouldBe(ParserResultType.Parsed);
+        return options!;
+    }
+}

--- a/Obj2Tiles/Options.cs
+++ b/Obj2Tiles/Options.cs
@@ -61,6 +61,9 @@ public sealed class Options
     [Option("octree", Required = false, HelpText = "Use octree spatial subdivision: each LOD gets one additional division level relative to the next coarser LOD, producing a proper tile hierarchy instead of same-count tiles per LOD.", Default = false)]
     public bool Octree { get; set; }
 
+    [Option("no-root-content", Required = false, HelpText = "Omit root.b3dm and emit a content-less tileset root. Requires a renderer that descends into children of content-less roots.", Default = false)]
+    public bool NoRootContent { get; set; }
+
     [Option("lod-texture-scale", Required = false, HelpText = "Per-LOD texture downscale factor. LOD-0 keeps full resolution (subject to --max-texture-size); each subsequent LOD multiplies the previous resolution by this factor. E.g. 0.5 gives LOD-1 at 1/2 resolution, LOD-2 at 1/4, etc. Use 1.0 to disable per-LOD downscaling.", Default = 0.5)]
     public double LodTextureScale { get; set; }
 

--- a/Obj2Tiles/Program.cs
+++ b/Obj2Tiles/Program.cs
@@ -151,7 +151,7 @@ namespace Obj2Tiles
                 // which keeps it as a single mesh but compresses its textures, so the bootstrap root tile
                 // stays small instead of embedding the full-resolution source textures.
                 string? rootSourceObj = null;
-                if (decimateRes.DestFiles.Length > 0)
+                if (!opts.NoRootContent && decimateRes.DestFiles.Length > 0)
                 {
                     rootSourceObj = decimateRes.DestFiles[^1];
                     try

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ By default Obj2Tiles writes a loose folder tree (`tileset.json`, `LOD-*/` and `r
 |-----------|---------|-------------|---------|
 | `--3tz` | `false` | Produce a single `.3tz` archive instead of a folder tree (implied by a `.3tz` output path). When set without a `.3tz` extension, the archive is written to `<output>.3tz` | `--3tz` |
 | `--3tz-compression` | `6` | DEFLATE level for `.3tz` content, `0`-`9` (gzip-style), see table below. The index is always stored uncompressed | `--3tz-compression 9` |
+| `--no-root-content` | `false` | Omit `root.b3dm` and emit a legal contentless tileset root. Useful when only separately audited child tiles should be published, but requires a renderer that descends into children of contentless roots | `--no-root-content` |
 
 **Compression levels (`--3tz-compression`):**
 


### PR DESCRIPTION
## Summary

- add an opt-in `--no-root-content` CLI switch (default remains `false`)
- pass no `rootSourceObj` to the existing tiling path when requested, producing its legal contentless `ADD` root and no `root.b3dm`
- document the renderer compatibility tradeoff

## Motivation

Privacy-audited and geometry-decimation workflows may intentionally publish only separately accepted child tiles. The automatically generated whole-model root is then a redundant artifact with a distinct release/audit surface. This switch lets those workflows omit it without post-processing `tileset.json` or deleting output after generation.

The option does not crop or validate geometry. It only selects Obj2Tiles' already-supported contentless-root behavior. It is deliberately off by default because some renderers do not descend into children of a contentless root.

## Tests

- `dotnet test Obj2Tiles.Test/Obj2Tiles.Test.csproj -c Release`: 82 passed
- `dotnet test Obj2Tiles.Library.Test/Obj2Tiles.Library.Test.csproj -c Release`: 135 passed, 1 explicit test skipped
- CLI smoke test with `--lods 1 --divisions 0 --local --no-root-content`: exit 0, no `root.b3dm`, root `content: null`, root `refine: ADD`, child B3DM present