### PR TITLE
Expose KTX2 encoder thread count in CLI

### DIFF
--- a/Obj2Gltf/GltfConverterOptions.cs
+++ b/Obj2Gltf/GltfConverterOptions.cs
@@ -44,7 +44,7 @@ namespace SilentWave.Obj2Gltf
         public int Ktx2CompressionLevel { get; set; } = 1;
 
         /// <summary>
-        /// Number of encoder threads per ktx invocation. 0 lets ktx pick (hardware concurrency).
+        /// Number of encoder threads per KTX2 texture. 0 preserves the current single-threaded default.
         /// </summary>
         public int Ktx2Threads { get; set; } = 0;
 

--- a/Obj2Tiles.Test/Ktx2ThreadsOptionsTests.cs
+++ b/Obj2Tiles.Test/Ktx2ThreadsOptionsTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using CommandLine;
+using NUnit.Framework;
+using Obj2Tiles.Library.Geometry;
+using Shouldly;
+
+namespace Obj2Tiles.Test;
+
+public class Ktx2ThreadsOptionsTests
+{
+    [Test]
+    public void Ktx2Threads_DefaultsToZero()
+    {
+        Parse("input.obj", "output").Ktx2Threads.ShouldBe(0);
+    }
+
+    [Test]
+    public void Ktx2Threads_ParsesPositiveValue()
+    {
+        var options = Parse("--texture-format", "Ktx2", "--ktx2-threads", "4", "input.obj", "output");
+
+        options.TextureFormat.ShouldBe(TextureFormat.Ktx2);
+        options.Ktx2Threads.ShouldBe(4);
+    }
+
+    [Test]
+    public void Ktx2Threads_NegativeValueIsRejected()
+    {
+        CheckOptions("--texture-format", "Ktx2", "--ktx2-threads", "-1").ShouldBeFalse();
+    }
+
+    [Test]
+    public void Ktx2Threads_PositiveValueRequiresKtx2()
+    {
+        CheckOptions("--ktx2-threads", "4").ShouldBeFalse();
+    }
+
+    [Test]
+    public void Ktx2Threads_PositiveValueWithKtx2IsAccepted()
+    {
+        CheckOptions("--texture-format", "Ktx2", "--ktx2-threads", "4").ShouldBeTrue();
+    }
+
+    private static Options Parse(params string[] args)
+    {
+        Options? options = null;
+        using var parser = new Parser(settings => settings.HelpWriter = null);
+        var result = parser.ParseArguments<Options>(args);
+        result.WithParsed(parsed => options = parsed);
+        result.Tag.ShouldBe(ParserResultType.Parsed);
+        return options!;
+    }
+
+    private static bool CheckOptions(params string[] optionArgs)
+    {
+        var input = Path.GetTempFileName();
+        try
+        {
+            var args = optionArgs.Concat([input, Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())]).ToArray();
+            var options = Parse(args);
+            var programType = typeof(Options).Assembly.GetType("Obj2Tiles.Program", throwOnError: true)!;
+            var method = programType.GetMethod("CheckOptions", BindingFlags.NonPublic | BindingFlags.Static)!;
+            return (bool)method.Invoke(null, [options])!;
+        }
+        finally
+        {
+            File.Delete(input);
+        }
+    }
+}

--- a/Obj2Tiles/Options.cs
+++ b/Obj2Tiles/Options.cs
@@ -79,6 +79,9 @@ public sealed class Options
     [Option("ktx2-uastc", Required = false, HelpText = "Use UASTC (higher quality, larger, transcodes to BC7/ASTC) instead of the default ETC1S/BasisLZ mode for KTX2 textures.", Default = false)]
     public bool Ktx2Uastc { get; set; }
 
+    [Option("ktx2-threads", Required = false, HelpText = "Number of libktx encoder threads per texture. 0 preserves the current single-threaded encoder behavior; positive values require --texture-format Ktx2.", Default = 0)]
+    public int Ktx2Threads { get; set; }
+
     [Option("ktx-path", Required = false, HelpText = "Explicit path to the libktx native library (ktx.dll / libktx.so / libktx.dylib) or the directory containing it, used for --texture-format Ktx2. When omitted it is resolved from the OBJ2TILES_KTX environment variable, next to the executable (bundled), or on the system library path.", Default = null)]
     public string? KtxPath { get; set; }
 

--- a/Obj2Tiles/Program.cs
+++ b/Obj2Tiles/Program.cs
@@ -205,6 +205,7 @@ namespace Obj2Tiles
                         EncodeKtx2 = true,
                         Ktx2Uastc = opts.Ktx2Uastc,
                         Ktx2QualityLevel = opts.Ktx2Quality,
+                        Ktx2Threads = opts.Ktx2Threads,
                         KtxToolPath = opts.KtxPath
                     };
                 }
@@ -328,6 +329,18 @@ namespace Obj2Tiles
             if (opts.LodTextureScale is <= 0 or > 1)
             {
                 Console.WriteLine(" !> --lod-texture-scale must be in the (0, 1] range");
+                return false;
+            }
+
+            if (opts.Ktx2Threads < 0)
+            {
+                Console.WriteLine(" !> --ktx2-threads must be non-negative (0 preserves the current default)");
+                return false;
+            }
+
+            if (opts.Ktx2Threads > 0 && opts.TextureFormat != TextureFormat.Ktx2)
+            {
+                Console.WriteLine(" !> --ktx2-threads requires --texture-format Ktx2");
                 return false;
             }
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Controls how repacked texture atlases are encoded.
 | `--max-texture-size` | `4096` | Maximum texture atlas resolution per side (pixels). Source textures larger than this are downscaled. `0` disables the cap | `--max-texture-size 2048` |
 | `--ktx2-quality` | `128` | KTX2 ETC1S/BasisLZ quality (1-255; higher = better quality, larger files). Reinterpreted as UASTC quality (0-4) when `--ktx2-uastc` is set. Only used with `--texture-format Ktx2` | `--ktx2-quality 200` |
 | `--ktx2-uastc` | `false` | Use UASTC instead of ETC1S/BasisLZ for KTX2 textures. UASTC transcodes to BC7/ASTC for near-lossless quality at ~3x the size of ETC1S. Only used with `--texture-format Ktx2` | `--ktx2-uastc` |
+| `--ktx2-threads` | `0` | Number of libktx encoder threads per texture. `0` preserves the current default of one encoder thread per texture; positive values require `--texture-format Ktx2` | `--ktx2-threads 4` |
 | `--ktx-path` |  | Path to the libktx native library or its directory. When omitted, resolved from `OBJ2TILES_KTX`, then the executable directory (where the bundled lib lives), then system `PATH`. Only used with `--texture-format Ktx2` | `--ktx-path /usr/lib/libktx.so` |
 
 ### Geo-referencing
@@ -188,6 +189,8 @@ The `--texture-format Ktx2` option encodes every texture atlas as **KTX2 with Ba
 |------|------|---------------|---------------|----------|
 | **ETC1S / BasisLZ** (default) | *(none)* | `--ktx2-quality 1-255` | ETC2, BC1/BC3, PVRTC | Smallest files, maximum hardware compatibility |
 | **UASTC** | `--ktx2-uastc` | `--ktx2-quality 0-4` | BC7, ASTC, ETC2 | Near-lossless quality, ~3x larger than ETC1S |
+
+Obj2Tiles already converts multiple tiles concurrently. `--ktx2-threads N` additionally gives each active texture encode `N` libktx worker threads; leave it at `0` to retain the current one-thread-per-texture behavior, or raise it cautiously to avoid oversubscribing the machine.
 
 **Renderer requirements:**
 


### PR DESCRIPTION
## Summary

- expose the existing `GltfConverterOptions.Ktx2Threads` setting as `--ktx2-threads`
- keep `0` as the unchanged one-thread-per-texture default
- reject negative values and positive values without `--texture-format Ktx2`
- document per-texture threading and the risk of oversubscription because tile conversion is already parallel

This is a KTX2-specific, backward-compatible seam related to #8; it does not attempt to cap the other parallel pipeline stages.

## Validation

- `dotnet test Obj2Tiles.sln --configuration Release --verbosity minimal`
  - `Obj2Tiles.Library.Test`: 135 passed
  - `Obj2Tiles.Test`: 85 passed
- focused option contract: 5 passed
- real native libktx smoke conversion with `--ktx2-threads 2`: exit 0, `tileset.json` plus two B3DM outputs