### PR TITLE
Add opt-in Zstd supercompression for UASTC KTX2

### DIFF
--- a/Obj2Gltf/GltfConverterOptions.cs
+++ b/Obj2Gltf/GltfConverterOptions.cs
@@ -49,6 +49,11 @@ namespace SilentWave.Obj2Gltf
         public int Ktx2Threads { get; set; } = 0;
 
         /// <summary>
+        /// Zstandard supercompression level [1,22] for UASTC KTX2 textures. 0 disables it.
+        /// </summary>
+        public int Ktx2ZstdLevel { get; set; } = 0;
+
+        /// <summary>
         /// Optional path to the native KTX-Software library (libktx: ktx.dll / libktx.so / libktx.dylib)
         /// or the directory containing it, used for KTX2 encoding via P/Invoke. When null the library is
         /// resolved from the OBJ2TILES_KTX environment variable, next to the executable, or on the

--- a/Obj2Gltf/Ktx2/Ktx2Encoder.cs
+++ b/Obj2Gltf/Ktx2/Ktx2Encoder.cs
@@ -101,6 +101,9 @@ namespace SilentWave.Obj2Gltf.Ktx2
         [DllImport("ktx", CallingConvention = CallingConvention.Cdecl)]
         private static extern int ktxTexture2_CompressBasisEx(IntPtr texture, ref KtxBasisParams parameters);
 
+        [DllImport("ktx", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int ktxTexture2_DeflateZstd(IntPtr texture, uint compressionLevel);
+
         // libktx decodes this path with MultiByteToWideChar(CP_UTF8, ...) on Windows and passes it
         // straight to fopen on other platforms, so it must be marshalled as UTF-8 (not the ANSI LPStr).
         [DllImport("ktx", CallingConvention = CallingConvention.Cdecl)]
@@ -201,6 +204,11 @@ namespace SilentWave.Obj2Gltf.Ktx2
         /// <param name="options">Encoder options.</param>
         public static void Encode(string inputImagePath, string outputKtx2Path, bool srgb, GltfConverterOptions options)
         {
+            if (options.Ktx2ZstdLevel is < 0 or > 22)
+                throw new ArgumentOutOfRangeException(nameof(options.Ktx2ZstdLevel), "KTX2 Zstd level must be 0 or between 1 and 22.");
+            if (options.Ktx2ZstdLevel > 0 && !options.Ktx2Uastc)
+                throw new InvalidOperationException("KTX2 Zstd supercompression requires UASTC.");
+
             Gate.Wait();
             try
             {
@@ -252,6 +260,12 @@ namespace SilentWave.Obj2Gltf.Ktx2
                     var basisParams = BuildParams(options);
                     err = ktxTexture2_CompressBasisEx(texture, ref basisParams);
                     Check(err, "ktxTexture2_CompressBasisEx");
+
+                    if (options.Ktx2ZstdLevel > 0)
+                    {
+                        err = ktxTexture2_DeflateZstd(texture, (uint)options.Ktx2ZstdLevel);
+                        Check(err, "ktxTexture2_DeflateZstd");
+                    }
 
                     var outputDir = Path.GetDirectoryName(outputKtx2Path);
                     if (!string.IsNullOrEmpty(outputDir))

--- a/Obj2Tiles.Test/Ktx2ZstdOptionsTests.cs
+++ b/Obj2Tiles.Test/Ktx2ZstdOptionsTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using CommandLine;
+using NUnit.Framework;
+using Obj2Tiles.Library.Geometry;
+using Shouldly;
+
+namespace Obj2Tiles.Test;
+
+public class Ktx2ZstdOptionsTests
+{
+    [Test]
+    public void Ktx2ZstdLevel_DefaultsToDisabled()
+    {
+        Parse("input.obj", "output").Ktx2ZstdLevel.ShouldBe(0);
+        CheckOptions().ShouldBeTrue();
+    }
+
+    [Test]
+    public void Ktx2ZstdLevel_ParsesValidLevel()
+    {
+        var options = Parse("--texture-format", "Ktx2", "--ktx2-uastc", "--ktx2-zstd-level", "18", "input.obj", "output");
+
+        options.Ktx2Uastc.ShouldBeTrue();
+        options.Ktx2ZstdLevel.ShouldBe(18);
+    }
+
+    [TestCase(-1)]
+    [TestCase(23)]
+    public void Ktx2ZstdLevel_OutOfRangeIsRejected(int level)
+    {
+        CheckOptions("--texture-format", "Ktx2", "--ktx2-uastc", "--ktx2-zstd-level", level.ToString()).ShouldBeFalse();
+    }
+
+    [Test]
+    public void Ktx2ZstdLevel_RequiresKtx2()
+    {
+        CheckOptions("--ktx2-uastc", "--ktx2-zstd-level", "18").ShouldBeFalse();
+    }
+
+    [Test]
+    public void Ktx2ZstdLevel_RequiresUastc()
+    {
+        CheckOptions("--texture-format", "Ktx2", "--ktx2-zstd-level", "18").ShouldBeFalse();
+    }
+
+    [Test]
+    public void Ktx2ZstdLevel_UastcKtx2IsAccepted()
+    {
+        CheckOptions("--texture-format", "Ktx2", "--ktx2-uastc", "--ktx2-zstd-level", "18").ShouldBeTrue();
+    }
+
+    private static Options Parse(params string[] args)
+    {
+        Options? options = null;
+        using var parser = new Parser(settings => settings.HelpWriter = null);
+        var result = parser.ParseArguments<Options>(args);
+        result.WithParsed(parsed => options = parsed);
+        result.Tag.ShouldBe(ParserResultType.Parsed);
+        return options!;
+    }
+
+    private static bool CheckOptions(params string[] optionArgs)
+    {
+        var input = Path.GetTempFileName();
+        try
+        {
+            var args = optionArgs.Concat([input, Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())]).ToArray();
+            var options = Parse(args);
+            var programType = typeof(Options).Assembly.GetType("Obj2Tiles.Program", throwOnError: true)!;
+            var method = programType.GetMethod("CheckOptions", BindingFlags.NonPublic | BindingFlags.Static)!;
+            return (bool)method.Invoke(null, [options])!;
+        }
+        finally
+        {
+            File.Delete(input);
+        }
+    }
+}

--- a/Obj2Tiles/Options.cs
+++ b/Obj2Tiles/Options.cs
@@ -79,6 +79,9 @@ public sealed class Options
     [Option("ktx2-uastc", Required = false, HelpText = "Use UASTC (higher quality, larger, transcodes to BC7/ASTC) instead of the default ETC1S/BasisLZ mode for KTX2 textures.", Default = false)]
     public bool Ktx2Uastc { get; set; }
 
+    [Option("ktx2-zstd-level", Required = false, HelpText = "Zstandard supercompression level for UASTC KTX2 textures (1-22; 0 disables). Requires --texture-format Ktx2 and --ktx2-uastc.", Default = 0)]
+    public int Ktx2ZstdLevel { get; set; }
+
     [Option("ktx-path", Required = false, HelpText = "Explicit path to the libktx native library (ktx.dll / libktx.so / libktx.dylib) or the directory containing it, used for --texture-format Ktx2. When omitted it is resolved from the OBJ2TILES_KTX environment variable, next to the executable (bundled), or on the system library path.", Default = null)]
     public string? KtxPath { get; set; }
 

--- a/Obj2Tiles/Program.cs
+++ b/Obj2Tiles/Program.cs
@@ -205,6 +205,7 @@ namespace Obj2Tiles
                         EncodeKtx2 = true,
                         Ktx2Uastc = opts.Ktx2Uastc,
                         Ktx2QualityLevel = opts.Ktx2Quality,
+                        Ktx2ZstdLevel = opts.Ktx2ZstdLevel,
                         KtxToolPath = opts.KtxPath
                     };
                 }
@@ -328,6 +329,24 @@ namespace Obj2Tiles
             if (opts.LodTextureScale is <= 0 or > 1)
             {
                 Console.WriteLine(" !> --lod-texture-scale must be in the (0, 1] range");
+                return false;
+            }
+
+            if (opts.Ktx2ZstdLevel is < 0 or > 22)
+            {
+                Console.WriteLine(" !> --ktx2-zstd-level must be 0 (disabled) or between 1 and 22");
+                return false;
+            }
+
+            if (opts.Ktx2ZstdLevel > 0 && opts.TextureFormat != TextureFormat.Ktx2)
+            {
+                Console.WriteLine(" !> --ktx2-zstd-level requires --texture-format Ktx2");
+                return false;
+            }
+
+            if (opts.Ktx2ZstdLevel > 0 && !opts.Ktx2Uastc)
+            {
+                Console.WriteLine(" !> --ktx2-zstd-level requires --ktx2-uastc");
                 return false;
             }
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Controls how repacked texture atlases are encoded.
 | `--max-texture-size` | `4096` | Maximum texture atlas resolution per side (pixels). Source textures larger than this are downscaled. `0` disables the cap | `--max-texture-size 2048` |
 | `--ktx2-quality` | `128` | KTX2 ETC1S/BasisLZ quality (1-255; higher = better quality, larger files). Reinterpreted as UASTC quality (0-4) when `--ktx2-uastc` is set. Only used with `--texture-format Ktx2` | `--ktx2-quality 200` |
 | `--ktx2-uastc` | `false` | Use UASTC instead of ETC1S/BasisLZ for KTX2 textures. UASTC transcodes to BC7/ASTC for near-lossless quality at ~3x the size of ETC1S. Only used with `--texture-format Ktx2` | `--ktx2-uastc` |
+| `--ktx2-zstd-level` | `0` | Zstandard supercompression level for UASTC KTX2 textures (`1`-`22`; `0` disables). Requires `--texture-format Ktx2` and `--ktx2-uastc`; levels above `20` use substantially more memory | `--ktx2-zstd-level 18` |
 | `--ktx-path` |  | Path to the libktx native library or its directory. When omitted, resolved from `OBJ2TILES_KTX`, then the executable directory (where the bundled lib lives), then system `PATH`. Only used with `--texture-format Ktx2` | `--ktx-path /usr/lib/libktx.so` |
 
 ### Geo-referencing
@@ -189,6 +190,8 @@ The `--texture-format Ktx2` option encodes every texture atlas as **KTX2 with Ba
 | **ETC1S / BasisLZ** (default) | *(none)* | `--ktx2-quality 1-255` | ETC2, BC1/BC3, PVRTC | Smallest files, maximum hardware compatibility |
 | **UASTC** | `--ktx2-uastc` | `--ktx2-quality 0-4` | BC7, ASTC, ETC2 | Near-lossless quality, ~3x larger than ETC1S |
 
+UASTC data can optionally be losslessly supercompressed with Zstandard by setting `--ktx2-zstd-level 1-22`. Higher levels trade encoding time and memory for smaller files; levels above 20 require substantially more memory. ETC1S already uses BasisLZ supercompression and cannot be combined with Zstandard.
+
 **Renderer requirements:**
 
 Not all renderers support `KHR_texture_basisu`. Verified to work: CesiumJS, CesiumNative, Babylon.js, three.js (with `KTX2Loader`), and most WebGPU-capable renderers. Use `--texture-format Jpeg` (the default) for environments where `KHR_texture_basisu` support is uncertain.
@@ -266,6 +269,12 @@ UASTC mode for near-lossless quality targeting BC7/ASTC renderers (larger files)
 
 ```bash
 Obj2Tiles --texture-format Ktx2 --ktx2-uastc --ktx2-quality 3 --local model.obj ./output
+```
+
+Add lossless Zstandard supercompression to UASTC output:
+
+```bash
+Obj2Tiles --texture-format Ktx2 --ktx2-uastc --ktx2-quality 3 --ktx2-zstd-level 18 --local model.obj ./output
 ```
 
 Cap atlas size to 2048 px and raise JPEG quality for the default format:


### PR DESCRIPTION
## Summary

- add opt-in `--ktx2-zstd-level 1-22` for UASTC KTX2 output
- keep `0` as the default, preserving the existing output path
- call the existing libktx `ktxTexture2_DeflateZstd` API after `ktxTexture2_CompressBasisEx`
- reject out-of-range levels, non-KTX output, and ETC1S/BasisLZ combinations
- document the UASTC-only constraint and memory caution for levels above 20

The range and ETC1S restriction follow the [official KTX tools contract](https://github.khronos.org/KTX-Software/ktxtools/ktx_deflate.html). This PR is independent of #102 and does not include its thread-count CLI change.

## Validation

- `dotnet test Obj2Tiles.sln --configuration Release --verbosity minimal`
  - `Obj2Tiles.Library.Test`: 135 passed
  - `Obj2Tiles.Test`: 87 passed
- focused option contract: 7 passed
- real native conversion using the vendored Windows x64 libktx v4.4.2: exit 0, `tileset.json` and two B3DM outputs
- vendored `ktx.dll` is byte-identical to the official v4.4.2 release DLL
- all 12 embedded KTX2 images report `supercompressionScheme = 2` (Zstd)
- official Khronos `ktx` v4.4.2, for every embedded image:
  - `validate --warnings-as-errors --gltf-basisu`: passed
  - `transcode --target rgba8`: passed
  - validation of transcoded KTX2: passed